### PR TITLE
alipay_add_api

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ func main() {
     * 统一收单交易结算接口：client.TradeOrderSettle()
     * 支付宝订单信息同步接口：client.TradeOrderInfoSync()
     * 订单咨询服务：client.TradeAdvanceConsult()
-    * 聚合支付订单咨询服务 client.TradeOrderAggregateConsult()
+    * 聚合支付订单咨询服务 client.TradeOrderAggregateConsult()(失效)
 * 网页&移动应用 - <font color='#027AFF' size='4'>资金API</font>
     * 单笔转账接口：client.FundTransUniTransfer()
     * 查询转账订单接口: client.FundTransOrderQuery()

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ func main() {
     * 换取应用授权令牌：client.OpenAuthTokenApp()
     * 应用支付宝公钥证书下载：client.PublicCertDownload()
 * 网页&移动应用 - <font color='#027AFF' size='4'>芝麻信用API</font>
-  
+    * 芝麻企业信用信用评估初始化 client.ZhimaCreditEpSceneRatingInitialize()
 * 网页&移动应用 - <font color='#027AFF' size='4'>财务API</font>
     * 支付宝商家账户当前余额查询：client.DataBillBalanceQuery()（失效）
     * 查询对账单下载地址：client.DataBillDownloadUrlQuery()

--- a/README.md
+++ b/README.md
@@ -269,7 +269,6 @@ func main() {
     * 统一收单交易结算接口：client.TradeOrderSettle()
     * 支付宝订单信息同步接口：client.TradeOrderInfoSync()
     * 订单咨询服务：client.TradeAdvanceConsult()
-    * 聚合支付订单咨询服务 client.TradeOrderAggregateConsult()(失效)
 * 网页&移动应用 - <font color='#027AFF' size='4'>资金API</font>
     * 单笔转账接口：client.FundTransUniTransfer()
     * 查询转账订单接口: client.FundTransOrderQuery()
@@ -303,7 +302,7 @@ func main() {
     * 换取应用授权令牌：client.OpenAuthTokenApp()
     * 应用支付宝公钥证书下载：client.PublicCertDownload()
 * 网页&移动应用 - <font color='#027AFF' size='4'>芝麻信用API</font>
-    * 获取芝麻信用分：client.ZhimaCreditScoreGet()（失效）
+  
 * 网页&移动应用 - <font color='#027AFF' size='4'>财务API</font>
     * 支付宝商家账户当前余额查询：client.DataBillBalanceQuery()（失效）
     * 查询对账单下载地址：client.DataBillDownloadUrlQuery()

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ func main() {
     * 统一收单交易结算接口：client.TradeOrderSettle()
     * 支付宝订单信息同步接口：client.TradeOrderInfoSync()
     * 订单咨询服务：client.TradeAdvanceConsult()
+    * 聚合支付订单咨询服务 client.TradeOrderAggregateConsult()
 * 网页&移动应用 - <font color='#027AFF' size='4'>资金API</font>
     * 单笔转账接口：client.FundTransUniTransfer()
     * 查询转账订单接口: client.FundTransOrderQuery()

--- a/alipay/model.go
+++ b/alipay/model.go
@@ -1041,3 +1041,37 @@ type MerchantItemFileUpload struct {
 	MaterialId  string `json:"material_id"`  // 文件在商品中心的素材标识（素材ID长期有效）
 	MaterialKey string `json:"material_key"` // 文件在商品中心的素材标示，创建/更新商品时使用
 }
+
+// ===================================================
+type TradeOrderAggregateConsultRsp struct {
+	Response     *TradeOrderAggregateConsult `json:"koubei_trade_order_aggregate_consult_response"`
+	AlipayCertSn string                      `json:"alipay_cert_sn,omitempty"`
+	SignData     string                      `json:"-"`
+	Sign         string                      `json:"sign"`
+}
+
+type TradeOrderAggregateConsult struct {
+	ErrorResponse
+	OutOrderNo             string                `json:"out_order_no,omitempty"`
+	OrderNo                string                `json:"order_no,omitempty"`
+	TradeNo                string                `json:"trade_no,omitempty"`
+	BuyerId                string                `json:"buyer_id,omitempty"`
+	BuyerIdType            string                `json:"buyer_id_type,omitempty"`
+	TotalAmount            string                `json:"total_amount,omitempty"`
+	ReceiptAmount          string                `json:"receipt_amount,omitempty"`
+	BuyerPayAmount         string                `json:"buyer_pay_amount,omitempty"`
+	MerchantDiscountAmount string                `json:"merchant_discount_amount,omitempty"`
+	PlatformDiscountAmount string                `json:"platform_discount_amount,omitempty"`
+	DiscountDetailList     []*DiscountDetailInfo `json:"discount_detail_list,omitempty"`
+	OrderStatus            string                `json:"order_status,omitempty"`
+	PayChannel             string                `json:"pay_channel,omitempty"`
+	CreateTime             string                `json:"create_time"`
+	GmtPaymentTime         string                `json:"gmt_payment_time,omitempty"`
+}
+
+type DiscountDetailInfo struct {
+	Id     string `json:"id,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Type   string `json:"type,omitempty"`
+	Amount string `json:"amount,omitempty"`
+}

--- a/alipay/model.go
+++ b/alipay/model.go
@@ -1060,7 +1060,6 @@ type TradeCustomsDeclare struct {
 	Currency         string `json:"currency,omitempty"`
 	VerDept          string `json:"ver_dept,omitempty"`
 	IdentityCheck    string `json:"identity_check,omitempty"`
-
 }
 
 // ===================================================

--- a/alipay/model.go
+++ b/alipay/model.go
@@ -1095,3 +1095,16 @@ type DiscountDetailInfo struct {
 	Type   string `json:"type,omitempty"`
 	Amount string `json:"amount,omitempty"`
 }
+
+// ===================================================
+type ZhimaCreditEpSceneRatingInitializeRsp struct {
+	Response     *ZhimaCreditEpSceneRatingInitialize `json:"zhima_credit_ep_scene_rating_initialize_response"`
+	AlipayCertSn string                              `json:"alipay_cert_sn,omitempty"`
+	SignData     string                              `json:"-"`
+	Sign         string                              `json:"sign"`
+}
+
+type ZhimaCreditEpSceneRatingInitialize struct {
+	ErrorResponse
+	OrderNo string `json:"order_no"`
+}

--- a/alipay/model.go
+++ b/alipay/model.go
@@ -1095,5 +1095,4 @@ type DiscountDetailInfo struct {
 	Name   string `json:"name,omitempty"`
 	Type   string `json:"type,omitempty"`
 	Amount string `json:"amount,omitempty"`
-
-  
+}

--- a/alipay/payment_api.go
+++ b/alipay/payment_api.go
@@ -349,3 +349,24 @@ func (a *Client) TradeAdvanceConsult(bm gopay.BodyMap) (aliRsp *TradeAdvanceCons
 	aliRsp.SignData = signData
 	return aliRsp, a.autoVerifySignByCert(aliRsp.Sign, signData, signDataErr)
 }
+
+
+// koubei.trade.order.aggregate.consult(聚合支付订单咨询服务)
+//	文档地址：https://opendocs.alipay.com/apis/api_1/koubei.trade.order.aggregate.consult
+func (a *Client) TradeOrderAggregateConsult(bm gopay.BodyMap) (aliRsp *TradeOrderAggregateConsultRsp, err error) {
+	var bs []byte
+	if bs, err = a.doAliPay(bm, "koubei.trade.order.aggregate.consult"); err != nil {
+		return nil, err
+	}
+	aliRsp = new(TradeOrderAggregateConsultRsp)
+	if err = json.Unmarshal(bs, aliRsp); err != nil {
+		return nil, err
+	}
+	if aliRsp.Response != nil && aliRsp.Response.Code != "10000" {
+		info := aliRsp.Response
+		return nil, fmt.Errorf(`{"code":"%s","msg":"%s","sub_code":"%s","sub_msg":"%s"}`, info.Code, info.Msg, info.SubCode, info.SubMsg)
+	}
+	signData, signDataErr := a.getSignData(bs, aliRsp.AlipayCertSn)
+	aliRsp.SignData = signData
+	return aliRsp, a.autoVerifySignByCert(aliRsp.Sign, signData, signDataErr)
+}

--- a/alipay/payment_api.go
+++ b/alipay/payment_api.go
@@ -351,6 +351,7 @@ func (a *Client) TradeAdvanceConsult(bm gopay.BodyMap) (aliRsp *TradeAdvanceCons
 }
 
 
+// Deprecated
 // koubei.trade.order.aggregate.consult(聚合支付订单咨询服务)
 //	文档地址：https://opendocs.alipay.com/apis/api_1/koubei.trade.order.aggregate.consult
 func (a *Client) TradeOrderAggregateConsult(bm gopay.BodyMap) (aliRsp *TradeOrderAggregateConsultRsp, err error) {

--- a/alipay/payment_api.go
+++ b/alipay/payment_api.go
@@ -354,6 +354,10 @@ func (a *Client) TradeAdvanceConsult(bm gopay.BodyMap) (aliRsp *TradeAdvanceCons
 // koubei.trade.order.aggregate.consult(聚合支付订单咨询服务)
 //	文档地址：https://opendocs.alipay.com/apis/api_1/koubei.trade.order.aggregate.consult
 func (a *Client) TradeOrderAggregateConsult(bm gopay.BodyMap) (aliRsp *TradeOrderAggregateConsultRsp, err error) {
+	err = bm.CheckEmptyError("shop_id", "total_amount")
+	if err != nil {
+		return nil, err
+	}
 	var bs []byte
 	if bs, err = a.doAliPay(bm, "koubei.trade.order.aggregate.consult"); err != nil {
 		return nil, err

--- a/alipay/payment_api_test.go
+++ b/alipay/payment_api_test.go
@@ -245,3 +245,18 @@ func TestClient_TradeOrderSettle(t *testing.T) {
 	}
 	xlog.Debug("aliRsp:", *aliRsp)
 }
+
+// 订单咨询服务测试
+func TestTradeAdvanceConsult(t *testing.T) {
+	// 请求参数
+	bm := make(gopay.BodyMap)
+	bm.Set("alipay_user_id", "2088302483540171").
+		Set("consult_scene", "ORDER_RISK_EVALUATION")
+
+	aliRsp, err := client.TradeAdvanceConsult(bm)
+	if err != nil {
+		xlog.Errorf("client.TradeAdvanceConsult(%+v),error:%+v", bm, err)
+		return
+	}
+	xlog.Debug("aliRsp:", *aliRsp)
+}

--- a/alipay/zhima_api.go
+++ b/alipay/zhima_api.go
@@ -35,3 +35,30 @@ func (a *Client) ZhimaCreditScoreGet(bm gopay.BodyMap) (aliRsp *ZhimaCreditScore
 	aliRsp.SignData = signData
 	return aliRsp, a.autoVerifySignByCert(aliRsp.Sign, signData, signDataErr)
 }
+
+// zhima.credit.ep.scene.rating.initialize(芝麻企业信用信用评估初始化)
+//	文档地址：https://opendocs.alipay.com/apis/api_8/zhima.credit.ep.scene.rating.initialize
+func (a *Client) ZhimaCreditEpSceneRatingInitialize(bm gopay.BodyMap) (aliRsp *ZhimaCreditEpSceneRatingInitializeRsp, err error) {
+	if bm.GetString("product_code") == util.NULL {
+		bm.Set("product_code", "w1010100100000000001")
+	}
+	err = bm.CheckEmptyError("credit_category", "out_order_no", "user_id")
+	if err != nil {
+		return nil, err
+	}
+	var bs []byte
+	if bs, err = a.doAliPay(bm, "zhima.credit.ep.scene.rating.initialize"); err != nil {
+		return nil, err
+	}
+	aliRsp = new(ZhimaCreditEpSceneRatingInitializeRsp)
+	if err = json.Unmarshal(bs, aliRsp); err != nil {
+		return nil, err
+	}
+	if aliRsp.Response != nil && aliRsp.Response.Code != "10000" {
+		info := aliRsp.Response
+		return nil, fmt.Errorf(`{"code":"%s","msg":"%s","sub_code":"%s","sub_msg":"%s"}`, info.Code, info.Msg, info.SubCode, info.SubMsg)
+	}
+	signData, signDataErr := a.getSignData(bs, aliRsp.AlipayCertSn)
+	aliRsp.SignData = signData
+	return aliRsp, a.autoVerifySignByCert(aliRsp.Sign, signData, signDataErr)
+}

--- a/alipay/zhima_api_test.go
+++ b/alipay/zhima_api_test.go
@@ -4,20 +4,21 @@ import (
 	"testing"
 
 	"github.com/go-pay/gopay"
-	"github.com/go-pay/gopay/pkg/util"
 	"github.com/go-pay/gopay/pkg/xlog"
 )
 
-func TestClient_ZhimaCreditScoreGet(t *testing.T) {
+// 芝麻企业信用信用评估初始化测试
+func TestZhimaCreditEpSceneRatingInitialize(t *testing.T) {
 	// 请求参数
 	bm := make(gopay.BodyMap)
-	bm.Set("transaction_id", util.GetRandomString(48)).
-		Set("product_code", "w1010100100000000001")
+	bm.Set("credit_category", "ZMSCCO_5_1_1")
+	bm.Set("product_code", "w1010100100000000001")
+	bm.Set("out_order_no", "201805301527674106562F0000954216")
+	bm.Set("user_id", "2088302248028263")
 
-	// 芝麻分
-	aliRsp, err := client.ZhimaCreditScoreGet(bm)
+	aliRsp, err := client.ZhimaCreditEpSceneRatingInitialize(bm)
 	if err != nil {
-		xlog.Errorf("client.ZhimaCreditScoreGet(%+v),error:%+v", bm, err)
+		xlog.Errorf("client.ZhimaCreditEpSceneRatingInitialize(%+v),error:%+v", bm, err)
 		return
 	}
 	xlog.Debug("aliRsp:", *aliRsp)

--- a/examples/alipay/alipay_ZhimaCreditEpSceneRatingInitialize.go
+++ b/examples/alipay/alipay_ZhimaCreditEpSceneRatingInitialize.go
@@ -1,0 +1,35 @@
+package alipay
+
+import (
+	"github.com/go-pay/gopay"
+	"github.com/go-pay/gopay/alipay"
+	"github.com/go-pay/gopay/pkg/xlog"
+)
+
+func ZhimaCreditEpSceneRatingInitialize() {
+	privateKey := "MIIEogIBAAKCAQEAy+CRzKw4krA2RzCDTqg5KJg92XkOY0RN3pW4sYInPqnGtHV7YDHu5nMuxY6un+dLfo91OFOEg+RI+WTOPoM4xJtsOaJwQ1lpjycoeLq1OyetGW5Q8wO+iLWJASaMQM/t/aXR/JHaguycJyqlHSlxANvKKs/tOHx9AhW3LqumaCwz71CDF/+70scYuZG/7wxSjmrbRBswxd1Sz9KHdcdjqT8pmieyPqnM24EKBexHDmQ0ySXvLJJy6eu1dJsPIz+ivX6HEfDXmSmJ71AZVqZyCI1MhK813R5E7XCv5NOtskTe3y8uiIhgGpZSdB77DOyPLcmVayzFVLAQ3AOBDmsY6wIDAQABAoIBAHjsNq31zAw9FcR9orQJlPVd7vlJEt6Pybvmg8hNESfanO+16rpwg2kOEkS8zxgqoJ1tSzJgXu23fgzl3Go5fHcoVDWPAhUAOFre9+M7onh2nPXDd6Hbq6v8OEmFapSaf2b9biHnBHq5Chk08v/r74l501w3PVVOiPqulJrK1oVb+0/YmCvVFpGatBcNaefKUEcA+vekWPL7Yl46k6XeUvRfTwomCD6jpYLUhsAKqZiQJhMGoaLglZvkokQMF/4G78K7FbbVLMM1+JDh8zJ/DDVdY2vHREUcCGhl4mCVQtkzIbpxG++vFg7/g/fDI+PquG22hFILTDdtt2g2fV/4wmkCgYEA6goRQYSiM03y8Tt/M4u1Mm7OWYCksqAsU7rzQllHekIN3WjD41Xrjv6uklsX3sTG1syo7Jr9PGE1xQgjDEIyO8h/3lDQyLyycYnyUPGNNMX8ZjmGwcM51DQ/QfIrY/CXjnnW+MVpmNclAva3L33KXCWjw20VsROV1EA8LCL94BUCgYEA3wH4ANpzo7NqXf+2WlPPMuyRrF0QPIRGlFBNtaKFy0mvoclkREPmK7+N4NIGtMf5JNODS5HkFRgmU4YNdupA2I8lIYpD+TsIobZxGUKUkYzRZYZ1m1ttL69YYvCVz9Xosw/VoQ+RrW0scS5yUKqFMIUOV2R/Imi//c5TdKx6VP8CgYAnJ1ADugC4vI2sNdvt7618pnT3HEJxb8J6r4gKzYzbszlGlURQQAuMfKcP7RVtO1ZYkRyhmLxM4aZxNA9I+boVrlFWDAchzg+8VuunBwIslgLHx0/4EoUWLzd1/OGtco6oU1HXhI9J9pRGjqfO1iiIifN/ujwqx7AFNknayG/YkQKBgD6yNgA/ak12rovYzXKdp14Axn+39k2dPp6J6R8MnyLlB3yruwW6NSbNhtzTD1GZ+wCQepQvYvlPPc8zm+t3tl1r+Rtx3ORf5XBZc3iPkGdPOLubTssrrAnA+U9vph61W+OjqwLJ9sHUNK9pSHhHSIS4k6ycM2YAHyIC9NGTgB0PAoGAJjwd1DgMaQldtWnuXjvohPOo8cQudxXYcs6zVRbx6vtjKe2v7e+eK1SSVrR5qFV9AqxDfGwq8THenRa0LC3vNNplqostuehLhkWCKE7Y75vXMR7N6KU1kdoVWgN4BhXSwuRxmHMQfSY7q3HG3rDGz7mzXo1FVMr/uE4iDGm0IXY="
+	//初始化支付宝客户端
+	//    appId：应用ID
+	//    privateKey：应用私钥，支持PKCS1和PKCS8
+	//    isProd：是否是正式环境
+	client := alipay.NewClient("2014072300007148", privateKey, false)
+	//配置公共参数
+	client.SetCharset("utf-8").
+		SetSignType(alipay.RSA2).
+		SetPrivateKeyType(alipay.PKCS1)
+
+	//请求参数
+	body := make(gopay.BodyMap)
+	body.Set("credit_category", "ZMSCCO_5_1_1")
+	body.Set("product_code", "w1010100100000000001")
+	body.Set("out_order_no", "201805301527674106562F0000954216")
+	body.Set("user_id", "2088302248028263")
+
+	//创建订单
+	aliRsp, err := client.ZhimaCreditEpSceneRatingInitialize(body)
+	if err != nil {
+		xlog.Error("err:", err)
+		return
+	}
+	xlog.Debug("aliRsp:", *aliRsp)
+}

--- a/examples/alipay/alipay_ZhimaCreditEpSceneRatingInitialize.go
+++ b/examples/alipay/alipay_ZhimaCreditEpSceneRatingInitialize.go
@@ -25,7 +25,6 @@ func ZhimaCreditEpSceneRatingInitialize() {
 	body.Set("out_order_no", "201805301527674106562F0000954216")
 	body.Set("user_id", "2088302248028263")
 
-	//创建订单
 	aliRsp, err := client.ZhimaCreditEpSceneRatingInitialize(body)
 	if err != nil {
 		xlog.Error("err:", err)


### PR DESCRIPTION
1. 支付宝API-->聚合支付订单咨询服务`client.TradeOrderAggregateConsult()` --写完才发现已弃用 。。。。
2. README_update
3. 单元测试新增; 订单资讯服务单元测试+芝麻企业信用信用评估初始化
4. 新增API: alipay-芝麻企业信用信用评估初始化`ZhimaCreditEpSceneRatingInitialize`