### PR TITLE
goproxy support and expose transport settings

### DIFF
--- a/pkg/xhttp/client.go
+++ b/pkg/xhttp/client.go
@@ -133,6 +133,7 @@ func NewClient() (client *Client) {
 			Transport: &http.Transport{
 				TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
 				DisableKeepAlives: true,
+				Proxy:             http.ProxyFromEnvironment,
 			},
 		},
 		Transport:     nil,
@@ -142,6 +143,11 @@ func NewClient() (client *Client) {
 		Errors:        make([]error, 0),
 	}
 	return client
+}
+
+func (c *Client) SetTransport(transport *http.Transport) (client *Client) {
+	c.Transport = transport
+	return c
 }
 
 func (c *Client) SetTLSConfig(tlsCfg *tls.Config) (client *Client) {


### PR DESCRIPTION
希望 添加 对 Proxy支持  和  暴露 对 Transport的设置  ( Proxy支持 参考: http.DefaultTransport)
```golang
// NewClient , default tls.Config{InsecureSkipVerify: true}
func NewClient() (client *Client) {
	client = &Client{
		HttpClient: &http.Client{
			Timeout: 60 * time.Second,
			Transport: &http.Transport{
				TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
				DisableKeepAlives: true,
				Proxy: http.ProxyFromEnvironment,  
			},
		},
		Transport:     nil,
		Header:        make(http.Header),
		requestType:   TypeUrlencoded,
		unmarshalType: string(TypeJSON),
		Errors:        make([]error, 0),
	}
	return client
}

func (c *Client) SetTransport(transport *http.Transport) (client *Client) {
	c.Transport = transport
	return c
}
```

考虑到支付处理服务 可能处在 网络受限 状态下