### PR TITLE
新增微信V3申请分账账单，更新微信V3解冻剩余资金传参方式，更新部分Rsp兼容服务商模式

### DIFF
--- a/wechat/v3/client_test.go
+++ b/wechat/v3/client_test.go
@@ -335,7 +335,11 @@ func TestV3ProfitSharingQuery(t *testing.T) {
 }
 
 func TestV3ProfitSharingUnfreeze(t *testing.T) {
-	wxRsp, err := client.V3ProfitShareOrderUnfreeze("202106071738581338", "4200001037202106072686278117", "账单解冻")
+	bm := make(gopay.BodyMap)
+	bm.Set("transaction_id", "202106071738581338")
+	bm.Set("out_order_no", "4200001037202106072686278117")
+	bm.Set("description", "账单解冻")
+	wxRsp, err := client.V3ProfitShareOrderUnfreeze(bm)
 	if err != nil {
 		xlog.Error(err)
 		return

--- a/wechat/v3/constant.go
+++ b/wechat/v3/constant.go
@@ -157,6 +157,7 @@ const (
 	v3ProfitShareAddReceiver     = "/v3/profitsharing/receivers/add"           // 添加分账接收方 POST
 	v3ProfitShareDeleteReceiver  = "/v3/profitsharing/receivers/delete"        // 删除分账接收方 POST
 	v3ProfitShareMerchantConfigs = "/v3/profitsharing/merchant-configs/%s"     // 查询最大分账比例API GET
+	v3ProfitShareBills           = "/v3/profitsharing/bills"                   // 申请分账账单 GET
 
 	// 其他能力
 	v3MediaUploadImage = "/v3/merchant/media/upload"       // 图片上传 POST

--- a/wechat/v3/model.go
+++ b/wechat/v3/model.go
@@ -301,6 +301,14 @@ type ProfitShareMerchantConfigsRsp struct {
 	Error    string                      `json:"-"`
 }
 
+// 申请分账账单 Rsp
+type ProfitShareBillsRsp struct {
+	Code     int               `json:"-"`
+	SignInfo *SignInfo         `json:"-"`
+	Response *ProfitShareBills `json:"response,omitempty"`
+	Error    string            `json:"-"`
+}
+
 // 预受理领卡请求 Rsp
 type DiscountCardApplyRsp struct {
 	Code     int                `json:"-"`
@@ -1233,6 +1241,7 @@ type MediaUpload struct {
 }
 
 type ProfitShareOrder struct {
+	SubMchid      string                   `json:"sub_mchid,omitempty"` // 子商户号，即分账的出资商户号【服务商模式】
 	TransactionId string                   `json:"transaction_id"`      // 微信订单号
 	OutOrderNo    string                   `json:"out_order_no"`        // 商户分账单号
 	OrderId       string                   `json:"order_id"`            // 微信分账单号
@@ -1241,6 +1250,7 @@ type ProfitShareOrder struct {
 }
 
 type ProfitShareOrderQuery struct {
+	SubMchid      string                   `json:"sub_mchid,omitempty"` // 子商户号，即分账的出资商户号【服务商模式】
 	TransactionId string                   `json:"transaction_id"`      // 微信订单号
 	OutOrderNo    string                   `json:"out_order_no"`        // 商户分账单号
 	OrderId       string                   `json:"order_id"`            // 微信分账单号
@@ -1249,6 +1259,7 @@ type ProfitShareOrderQuery struct {
 }
 
 type ProfitShareReturn struct {
+	SubMchid    string `json:"sub_mchid,omitempty"`   // 子商户号，分账回退的接收商户，对应原分账出资的分账方商户【服务商模式】
 	OrderId     string `json:"order_id"`              // 微信分账单号，微信系统返回的唯一标识
 	OutOrderNo  string `json:"out_order_no"`          // 商户系统内部的分账单号，在商户系统内部唯一，同一分账单号多次请求等同一次。只能是数字、大小写字母_-|*@
 	OutReturnNo string `json:"out_return_no"`         // 此回退单号是商户在自己后台生成的一个新的回退单号，在商户后台唯一
@@ -1263,6 +1274,7 @@ type ProfitShareReturn struct {
 }
 
 type ProfitShareReturnResult struct {
+	SubMchid    string `json:"sub_mchid,omitempty"`   // 子商户号，分账回退的接收商户，对应原分账出资的分账方商户【服务商模式】
 	OrderId     string `json:"order_id"`              // 微信分账单号，微信系统返回的唯一标识
 	OutOrderNo  string `json:"out_order_no"`          // 商户系统内部的分账单号，在商户系统内部唯一，同一分账单号多次请求等同一次。只能是数字、大小写字母_-|*@
 	OutReturnNo string `json:"out_return_no"`         // 此回退单号是商户在自己后台生成的一个新的回退单号，在商户后台唯一
@@ -1277,6 +1289,7 @@ type ProfitShareReturnResult struct {
 }
 
 type ProfitShareOrderUnfreeze struct {
+	SubMchid      string                   `json:"sub_mchid,omitempty"` // 子商户号，分账回退的接收商户，对应原分账出资的分账方商户【服务商模式】
 	TransactionId string                   `json:"transaction_id"`      // 微信支付订单号
 	OutOrderNo    string                   `json:"out_order_no"`        // 商户系统内部的分账单号，在商户系统内部唯一，同一分账单号多次请求等同一次。只能是数字、大小写字母_-|*@
 	OrderId       string                   `json:"order_id"`            // 微信分账单号，微信系统返回的唯一标识
@@ -1302,6 +1315,7 @@ type ProfitSharingReceiver struct {
 }
 
 type ProfitShareAddReceiver struct {
+	SubMchid       string `json:"sub_mchid,omitempty"`       // 子商户号，分账回退的接收商户，对应原分账出资的分账方商户【服务商模式】
 	Type           string `json:"type"`                      // 分账接收方类型MERCHANT_ID：商户ID,PERSONAL_OPENID：个人openid（由父商户APPID转换得到）
 	Account        string `json:"account"`                   // 分账接收方帐号
 	Name           string `json:"name,omitempty"`            // 分账接收方类型是MERCHANT_ID时，是商户全称（必传），当商户是小微商户或个体户时，是开户人姓名 分账接收方类型是PERSONAL_OPENID时，是个人姓名（选传，传则校验）
@@ -1310,13 +1324,20 @@ type ProfitShareAddReceiver struct {
 }
 
 type ProfitShareDeleteReceiver struct {
-	Type    string `json:"type"`    // 分账接收方类型MERCHANT_ID：商户ID,PERSONAL_OPENID：个人openid（由父商户APPID转换得到）
-	Account string `json:"account"` // 分账接收方帐号
+	SubMchid string `json:"sub_mchid,omitempty"` // 子商户号，分账回退的接收商户，对应原分账出资的分账方商户【服务商模式】
+	Type     string `json:"type"`                // 分账接收方类型MERCHANT_ID：商户ID,PERSONAL_OPENID：个人openid（由父商户APPID转换得到）
+	Account  string `json:"account"`             // 分账接收方帐号
 }
 
 type ProfitShareMerchantConfigs struct {
 	SubMchId string `json:"sub_mchid"` // 子商户号
 	MaxRatio int    `json:"max_ratio"` // 最大分账比例 (单位万分比，比如2000表示20%)
+}
+
+type ProfitShareBills struct {
+	DownloadUrl string `json:"download_url"` // 下载地址	原始账单（gzip需要解压缩）的摘要值，用于校验文件的完整性。
+	HashType    string `json:"hash_type"`    // 哈希类型 原始账单（gzip需要解压缩）的摘要算法，用于校验文件的完整性
+	HashValue   string `json:"hash_value"`   // 哈希值	供下一步请求账单文件的下载地址，该地址30s内有效。
 }
 
 type DiscountCardApply struct {

--- a/wechat/v3/profit_share.go
+++ b/wechat/v3/profit_share.go
@@ -254,8 +254,8 @@ func (c *ClientV3) V3ProfitShareMerchantConfigs(subMchId string) (*ProfitShareMe
 //	Code = 0 is success
 // 直连商户：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_11.shtml
 // 服务商：https://pay.weixin.qq.com/wiki/doc/apiv3_partner/apis/chapter8_1_11.shtml
-func (c *ClientV3) V3ProfitShareBills(billDate string, bm gopay.BodyMap) (*ProfitShareBillsRsp, error) {
-	uri := fmt.Sprintf(v3ProfitShareBills, billDate) + "?" + bm.EncodeGetParams()
+func (c *ClientV3) V3ProfitShareBills(bm gopay.BodyMap) (*ProfitShareBillsRsp, error) {
+	uri := v3ProfitShareBills + "?" + bm.EncodeGetParams()
 	authorization, err := c.authorization(MethodGet, uri, nil)
 	if err != nil {
 		return nil, err

--- a/wechat/v3/profit_share.go
+++ b/wechat/v3/profit_share.go
@@ -120,10 +120,8 @@ func (c *ClientV3) V3ProfitShareReturnResult(returnNo string, bm gopay.BodyMap) 
 // 解冻剩余资金API
 //	Code = 0 is success
 // 	文档：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_5.shtml
-func (c *ClientV3) V3ProfitShareOrderUnfreeze(tradeNo, transId, description string) (*ProfitShareOrderUnfreezeRsp, error) {
-	bm := make(gopay.BodyMap)
-	bm.Set("transaction_id", transId).Set("out_order_no", tradeNo).Set("description", description)
-
+// 服务商模式会比直连商户模式多sub_mchid字段，改为gopay.BodyMap更灵活
+func (c *ClientV3) V3ProfitShareOrderUnfreeze(bm gopay.BodyMap) (*ProfitShareOrderUnfreezeRsp, error) {
 	authorization, err := c.authorization(MethodPost, v3ProfitShareUnfreeze, bm)
 	if err != nil {
 		return nil, err
@@ -241,6 +239,34 @@ func (c *ClientV3) V3ProfitShareMerchantConfigs(subMchId string) (*ProfitShareMe
 
 	wxRsp := &ProfitShareMerchantConfigsRsp{Code: Success, SignInfo: si}
 	wxRsp.Response = new(ProfitShareMerchantConfigs)
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("json.Unmarshal(%s)：%w", string(bs), err)
+	}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		return wxRsp, nil
+	}
+	return wxRsp, c.verifySyncSign(si)
+}
+
+// 申请分账账单
+//	Code = 0 is success
+// 直连商户：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter8_1_11.shtml
+// 服务商：https://pay.weixin.qq.com/wiki/doc/apiv3_partner/apis/chapter8_1_11.shtml
+func (c *ClientV3) V3ProfitShareBills(billDate string, bm gopay.BodyMap) (*ProfitShareBillsRsp, error) {
+	uri := fmt.Sprintf(v3ProfitShareBills, billDate) + "?" + bm.EncodeGetParams()
+	authorization, err := c.authorization(MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdGet(uri, authorization)
+	if err != nil {
+		return nil, err
+	}
+
+	wxRsp := &ProfitShareBillsRsp{Code: Success, SignInfo: si}
+	wxRsp.Response = new(ProfitShareBills)
 	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
 		return nil, fmt.Errorf("json.Unmarshal(%s)：%w", string(bs), err)
 	}


### PR DESCRIPTION
新增 微信v3申请分账账单
修改 微信v3解冻剩余资金传参方式为BodyMap，支持服务商模式
修改 微信v3分账接口，Rsp新增sub_mchid字段，兼容服务商模式。