### PR TITLE
支持替换 xhttp.Client 中的 HttpClient 为用户自定义实现了 HttpDoer 接口的客户端

### DIFF
--- a/alipay/sign.go
+++ b/alipay/sign.go
@@ -61,11 +61,11 @@ A：开发者上传自己的应用公钥证书后，开放平台会为开发者�
 //	返回 err：error 信息
 func GetCertSN(certPathOrData interface{}) (sn string, err error) {
 	var certData []byte
-	switch certPathOrData.(type) {
+	switch certPathOrData := certPathOrData.(type) {
 	case string:
-		certData, err = ioutil.ReadFile(certPathOrData.(string))
+		certData, err = ioutil.ReadFile(certPathOrData)
 	case []byte:
-		certData = certPathOrData.([]byte)
+		certData = certPathOrData
 	default:
 		return util.NULL, errors.New("certPathOrData 证书类型断言错误")
 	}
@@ -100,11 +100,11 @@ func GetRootCertSN(rootCertPathOrData interface{}) (sn string, err error) {
 		certData []byte
 		certEnd  = `-----END CERTIFICATE-----`
 	)
-	switch rootCertPathOrData.(type) {
+	switch rootCertPathOrData := rootCertPathOrData.(type) {
 	case string:
-		certData, err = ioutil.ReadFile(rootCertPathOrData.(string))
+		certData, err = ioutil.ReadFile(rootCertPathOrData)
 	case []byte:
-		certData = rootCertPathOrData.([]byte)
+		certData = rootCertPathOrData
 	default:
 		return util.NULL, errors.New("rootCertPathOrData 断言异常")
 	}

--- a/alipay/sign_test.go
+++ b/alipay/sign_test.go
@@ -89,6 +89,7 @@ func TestVerifySignWithCert(t *testing.T) {
 		xlog.Errorf("VerifySignWithCert(%+v),error:%+v", bm, err)
 		return
 	}
+	xlog.Debug("VerifySignWithCert", "OK:", ok)
 	// fileByte
 	bts, err := ioutil.ReadFile(filepath)
 	if err != nil {
@@ -100,7 +101,7 @@ func TestVerifySignWithCert(t *testing.T) {
 		xlog.Errorf("VerifySignWithCert(%+v),error:%+v", bm, err)
 		return
 	}
-	xlog.Debug("OK:", ok)
+	xlog.Debug("VerifySignWithCert", "OK:", ok)
 }
 
 func TestGetCertSN(t *testing.T) {

--- a/body_map.go
+++ b/body_map.go
@@ -97,7 +97,7 @@ func (bm BodyMap) MarshalXML(e *xml.Encoder, start xml.StartElement) (err error)
 	if len(bm) == 0 {
 		return nil
 	}
-	start.Name = xml.Name{NULL, "xml"}
+	start.Name = xml.Name{Space: NULL, Local: "xml"}
 	if err = e.EncodeToken(start); err != nil {
 		return
 	}

--- a/examples/alipay/alipay_TradeOrderSettle.go
+++ b/examples/alipay/alipay_TradeOrderSettle.go
@@ -27,7 +27,15 @@ func TradeOrderSettle() {
 	bm.Set("trade_no", "2019072522001484690549776067")
 
 	var listParams []*alipay.RoyaltyDetailInfoPojo
-	listParams = append(listParams, &alipay.RoyaltyDetailInfoPojo{"transfer", "2088802095984694", "userId", "userId", "2088102363632794", "0.01", "分账给2088102363632794"})
+	listParams = append(listParams, &alipay.RoyaltyDetailInfoPojo{
+		RoyaltyType:  "transfer",
+		TransOut:     "2088802095984694",
+		TransOutType: "userId",
+		TransInType:  "userId",
+		TransIn:      "2088102363632794",
+		Amount:       "0.01",
+		Desc:         "分账给2088102363632794",
+	})
 
 	bm.Set("royalty_parameters", listParams)
 	xlog.Debug("listParams:", bm.GetString("royalty_parameters"))

--- a/pkg/xhttp/client.go
+++ b/pkg/xhttp/client.go
@@ -42,7 +42,7 @@ type Client struct {
 	err              error
 }
 
-// DefaultHttpClient 默认为标准 *http.Client
+// DefaultHttpClient 默认为标准 *http.Client, default tls.Config{InsecureSkipVerify: true}
 // 如果使用者实现了自己的 HttpDoer, 请注意参考以下设置
 var DefaultHttpClient HttpDoer = &http.Client{
 	Timeout: 60 * time.Second,
@@ -53,8 +53,15 @@ var DefaultHttpClient HttpDoer = &http.Client{
 	},
 }
 
-// NewClient , default tls.Config{InsecureSkipVerify: true}
-func NewClient() (client *Client) {
+// WithHttpDoer 如果用户不想使用 DefaultHttpClient, 使用该方法即可
+func WithHttpDoer(doer HttpDoer) func(client *Client) {
+	return func(client *Client) {
+		client.HttpClient = doer
+	}
+}
+
+// NewClient 创建 *xhttp.Client
+func NewClient(opts ...func(client *Client)) (client *Client) {
 	client = &Client{
 		HttpClient:    DefaultHttpClient,
 		Transport:     nil,
@@ -62,6 +69,10 @@ func NewClient() (client *Client) {
 		requestType:   TypeJSON,
 		unmarshalType: string(TypeJSON),
 	}
+	for _, opt := range opts {
+		opt(client)
+	}
+
 	return client
 }
 

--- a/pkg/xhttp/client.go
+++ b/pkg/xhttp/client.go
@@ -43,7 +43,7 @@ type Client struct {
 }
 
 // DefaultHttpClient 默认为标准 *http.Client
-// 如果使用者实现了自己的 HttpDoer, 请注意设置 http.Client.Timeout 和 http.Client.Transport
+// 如果使用者实现了自己的 HttpDoer, 请注意参考以下设置
 var DefaultHttpClient HttpDoer = &http.Client{
 	Timeout: 60 * time.Second,
 	Transport: &http.Transport{
@@ -65,19 +65,19 @@ func NewClient() (client *Client) {
 	return client
 }
 
-// SetTransport 仅在 DefaultHttpClient 为标准 http.Client 时可使用
+// SetTransport 仅在 DefaultHttpClient 为标准 *http.Client 时可生效
 func (c *Client) SetTransport(transport *http.Transport) (client *Client) {
 	c.Transport = transport
 	return c
 }
 
-// SetTLSConfig 仅在 DefaultHttpClient 为标准 http.Client 时可使用
+// SetTLSConfig 仅在 DefaultHttpClient 为标准 *http.Client 时可生效
 func (c *Client) SetTLSConfig(tlsCfg *tls.Config) (client *Client) {
 	c.Transport = &http.Transport{TLSClientConfig: tlsCfg, DisableKeepAlives: true, Proxy: http.ProxyFromEnvironment}
 	return c
 }
 
-// SetTimeout 仅在 DefaultHttpClient 为标准 http.Client 时可使用
+// SetTimeout 仅在 DefaultHttpClient 为标准 *http.Client 时可生效
 func (c *Client) SetTimeout(timeout time.Duration) (client *Client) {
 	c.Timeout = timeout
 	return c
@@ -296,7 +296,7 @@ func (c *Client) EndBytes(ctx context.Context) (res *http.Response, bs []byte, e
 			return errors.New("Only support GET and POST and PUT and DELETE ")
 		}
 
-		req, err := http.NewRequest(c.method, c.url, body)
+		req, err := http.NewRequestWithContext(ctx, c.method, c.url, body)
 		if err != nil {
 			return err
 		}

--- a/pkg/xhttp/client_test.go
+++ b/pkg/xhttp/client_test.go
@@ -23,7 +23,7 @@ var (
 
 func TestHttpGet(t *testing.T) {
 	client := NewClient()
-	client.Timeout = 10 * time.Second
+	client.timeout = 10 * time.Second
 	// test
 	_, bs, err := client.Get("http://www.baidu.com").EndBytes(ctx)
 	if err != nil {
@@ -56,7 +56,7 @@ func TestHttpUploadFile(t *testing.T) {
 	}).SetFormFile("image", &util.File{Name: "logo.png", Content: fileContent})
 
 	client := NewClient()
-	client.Timeout = 10 * time.Second
+	client.timeout = 10 * time.Second
 
 	rsp := new(HttpGet)
 	_, err = client.Type(TypeMultipartFormData).

--- a/qq/param.go
+++ b/qq/param.go
@@ -54,13 +54,13 @@ func checkCertFilePathOrContent(certFile, keyFile, pkcs12File interface{}) error
 	if certFile != nil && keyFile != nil {
 		files := map[string]interface{}{"certFile": certFile, "keyFile": keyFile}
 		for varName, v := range files {
-			switch v.(type) {
+			switch v := v.(type) {
 			case string:
-				if v.(string) == util.NULL {
+				if v == util.NULL {
 					return fmt.Errorf("%s is empty", varName)
 				}
 			case []byte:
-				if len(v.([]byte)) == 0 {
+				if len(v) == 0 {
 					return fmt.Errorf("%s is empty", varName)
 				}
 			default:
@@ -69,13 +69,13 @@ func checkCertFilePathOrContent(certFile, keyFile, pkcs12File interface{}) error
 		}
 		return nil
 	} else if pkcs12File != nil {
-		switch pkcs12File.(type) {
+		switch pkcs12File := pkcs12File.(type) {
 		case string:
-			if pkcs12File.(string) == util.NULL {
+			if pkcs12File == util.NULL {
 				return errors.New("pkcs12File is empty")
 			}
 		case []byte:
-			if len(pkcs12File.([]byte)) == 0 {
+			if len(pkcs12File) == 0 {
 				return errors.New("pkcs12File is empty")
 			}
 		default:

--- a/wechat/param.go
+++ b/wechat/param.go
@@ -164,13 +164,13 @@ func checkCertFilePathOrContent(certFile, keyFile, pkcs12File interface{}) error
 	if certFile != nil && keyFile != nil {
 		files := map[string]interface{}{"certFile": certFile, "keyFile": keyFile}
 		for varName, v := range files {
-			switch v.(type) {
+			switch v := v.(type) {
 			case string:
-				if v.(string) == util.NULL {
+				if v == util.NULL {
 					return fmt.Errorf("%s is empty", varName)
 				}
 			case []byte:
-				if len(v.([]byte)) == 0 {
+				if len(v) == 0 {
 					return fmt.Errorf("%s is empty", varName)
 				}
 			default:
@@ -179,13 +179,13 @@ func checkCertFilePathOrContent(certFile, keyFile, pkcs12File interface{}) error
 		}
 		return nil
 	} else if pkcs12File != nil {
-		switch pkcs12File.(type) {
+		switch pkcs12File := pkcs12File.(type) {
 		case string:
-			if pkcs12File.(string) == util.NULL {
+			if pkcs12File == util.NULL {
 				return errors.New("pkcs12File is empty")
 			}
 		case []byte:
-			if len(pkcs12File.([]byte)) == 0 {
+			if len(pkcs12File) == 0 {
 				return errors.New("pkcs12File is empty")
 			}
 		default:

--- a/wechat/v3/cert.go
+++ b/wechat/v3/cert.go
@@ -262,14 +262,12 @@ func (c *ClientV3) autoCheckCertProc() {
 		wxPk, wxSerialNo, err := c.GetAndSelectNewestCert()
 		if err != nil {
 			xlog.Errorf("c.GetAndSelectNewestCert()，err:%+v", err)
-			err = nil
 			continue
 		}
 		// decode cert
 		pubKey, err := xpem.DecodePublicKey([]byte(wxPk))
 		if err != nil {
 			xlog.Errorf("xpem.DecodePublicKey(%s)，err:%+v", wxPk, err)
-			err = nil
 			continue
 		}
 		c.wxPublicKey = pubKey


### PR DESCRIPTION
在如下的追踪链中, 丢失了请求微信的过程.

![image](https://user-images.githubusercontent.com/35254251/142558509-c002e26f-8f5c-4b99-a27b-1f50e893a2c4.png)

部分用户可能需要替换Http客户端为自己实现的客户端, 方便添加 Hook 或者其他操作.

我的想法是添加 `HttpDoer` 接口 和 全局的 `DefaultHttpClient` 实现的.

请大佬指点.

```
type mockDoer struct {
	doer *http.Client
}

func (c mockDoer)Do(req *http.Request) (*http.Response, error) {
       // 记录日志等...
       // log(req)


        res,err := c.doer.Do(req)

       // log(res)

	return res, err
}
```

因为使用的是全局的 DefaultHttpClient.
gopay里已经在使用的 xhttp.NewClient 是不用修改的, 使用者直接替换这个默认值, 就可以调用自己封装的`Do`方法
```
doer := &mockDoer{doer: &http.Client{ Timeout: 10*time.Second }}
xhttp.DefaultHttpClient = doer
```

如果有用户使用了gopay的 xhttp 包, 但是不想使用 `xhttp.DefaultHttpClient`, 那么也可以选择用 `WithHttpDoer` 方法替换
```
doer := &mockDoer{doer: &http.Client{ Timeout: 10*time.Second }}
client := xhttp.NewClient(xhttp.WithHttpDoer(doer))
```

