### PR TITLE
fix: 撤回 HttpDoer

### DIFF
--- a/pkg/xhttp/client.go
+++ b/pkg/xhttp/client.go
@@ -284,7 +284,7 @@ func (c *Client) EndBytes(ctx context.Context) (res *http.Response, bs []byte, e
 			return errors.New("Only support GET and POST and PUT and DELETE ")
 		}
 
-		req, err := http.NewRequest(c.method, c.url, body)
+		req, err := http.NewRequestWithContext(ctx, c.method, c.url, body)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
原先目的是让 `xhttp.Client` 中使用的 `http.Client` 可以定制化, 就是项目里的 http 请求, 统一走用户定制的 `http.Client`
而不是 gopay 自己 New 一个独立的 `http.Client`

添加了全局的 `DefaultHttpClient`, 这样我就可以 `DefaultHttpClient = CustomClient`,  gopay 里的代码就不用改了

但是想当然了, `SetTlsConfig` 的时候, 在真正请求的时候, `httpClient.Transport = c.Transport` 这一块, 因为 `*http.Client` 指针, 就是异步操作了, 只能最后每次 Set 的时候要加锁.

然后 `HttpDoer` 接口, 可能不是标准的 `http.Client`, Set 方法是不能生效的,
如果 `DefaultHttpClient = CustomDoer` 的话, gopay 里现在使用的 Set 方法就没用了, 证书添加不上.
也就是 xhttp 请求用的 Client 的类型还必须只能是 `http.Client`, 不能是通用的 `HttpDoer` 接口.

所以这里撤回这个修改, 如果你已经使用了包含这个pr的版本, 非常抱歉