### PR TITLE
自动签约接口修改

### DIFF
--- a/alipay/member_api.go
+++ b/alipay/member_api.go
@@ -98,7 +98,7 @@ func (a *Client) UserCertifyOpenQuery(ctx context.Context, bm gopay.BodyMap) (al
 	return aliRsp, a.autoVerifySignByCert(aliRsp.Sign, signData, signDataErr)
 }
 
-// alipay.user.agreement.page.sign(支付宝个人协议页面签约接口)
+// UserAgreementPageSign alipay.user.agreement.page.sign(支付宝个人协议页面签约接口)
 //	文档地址：https://opendocs.alipay.com/apis/api_2/alipay.user.agreement.page.sign
 func (a *Client) UserAgreementPageSign(ctx context.Context, bm gopay.BodyMap) (aliRsp *UserAgreementPageSignRsp, err error) {
 	err = bm.CheckEmptyError("personal_product_code")
@@ -120,6 +120,20 @@ func (a *Client) UserAgreementPageSign(ctx context.Context, bm gopay.BodyMap) (a
 	signData, signDataErr := a.getSignData(bs, aliRsp.AlipayCertSn)
 	aliRsp.SignData = signData
 	return aliRsp, a.autoVerifySignByCert(aliRsp.Sign, signData, signDataErr)
+}
+
+// UserAgreementSignPage alipay.user.agreement.page.sign(支付宝个人协议页面签约接口)
+//	文档地址：https://opendocs.alipay.com/apis/api_2/alipay.user.agreement.page.sign
+func (a *Client) UserAgreementSignPage(ctx context.Context, bm gopay.BodyMap) (page string, err error) {
+	err = bm.CheckEmptyError("personal_product_code")
+	if err != nil {
+		return "", err
+	}
+	var bs []byte
+	if bs, err = a.doAliPay(ctx, bm, "alipay.user.agreement.page.sign"); err != nil {
+		return "", err
+	}
+	return string(bs), nil
 }
 
 // alipay.user.agreement.unsign(支付宝个人代扣协议解约接口)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/go-pay/gopay
+module github.com/Caisin/gopay
 
-go 1.16
+go 1.17
 
 require golang.org/x/crypto v0.0.0-20211202192323-5770296d904e

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Caisin/gopay
+module github.com/go-pay/gopay
 
 go 1.17
 


### PR DESCRIPTION
支付宝自动签约接口返回的是一个html字符串,不是json
在浏览器或者webview调用这个html会跳转支付宝签约,签约成功会通知后台