### PR TITLE
Error response enhancement

### DIFF
--- a/alipay/error.go
+++ b/alipay/error.go
@@ -1,0 +1,18 @@
+package alipay
+
+import "fmt"
+
+type ErrorResponse struct {
+	Code    string `json:"code"`
+	Msg     string `json:"msg"`
+	SubCode string `json:"sub_code,omitempty"`
+	SubMsg  string `json:"sub_msg,omitempty"`
+}
+
+func (ersp ErrorResponse) HasBizError() bool {
+	return ersp.Code != "10000"
+}
+
+func (ersp ErrorResponse) Error() string {
+	return fmt.Sprintf(`{"code": "%s","msg": "%s","sub_code": "%s","sub_msg": "%s"}`, ersp.Code, ersp.Msg, ersp.SubCode, ersp.SubMsg)
+}

--- a/alipay/error.go
+++ b/alipay/error.go
@@ -2,17 +2,34 @@ package alipay
 
 import "fmt"
 
-type ErrorResponse struct {
-	Code    string `json:"code"`
-	Msg     string `json:"msg"`
-	SubCode string `json:"sub_code,omitempty"`
-	SubMsg  string `json:"sub_msg,omitempty"`
+// BizErr 用于判断支付宝的业务逻辑是否有错误
+type BizErr struct {
+	Code    string
+	Msg     string
+	SubCode string
+	SubMsg  string
 }
 
-func (ersp ErrorResponse) HasBizError() bool {
-	return ersp.Code != "10000"
+// bizErrCheck 检查业务码是否为10000 否则返回一个BizErr
+func bizErrCheck(errRsp ErrorResponse) error {
+	if errRsp.Code != "10000" {
+		return &BizErr{
+			Code:    errRsp.SubCode,
+			Msg:     errRsp.Msg,
+			SubCode: errRsp.SubCode,
+			SubMsg:  errRsp.SubMsg,
+		}
+	}
+	return nil
 }
 
-func (ersp ErrorResponse) Error() string {
-	return fmt.Sprintf(`{"code": "%s","msg": "%s","sub_code": "%s","sub_msg": "%s"}`, ersp.Code, ersp.Msg, ersp.SubCode, ersp.SubMsg)
+func (e *BizErr) Error() string {
+	return fmt.Sprintf(`{"code": "%s","msg": "%s","sub_code": "%s","sub_msg": "%s"}`, e.Code, e.Msg, e.SubCode, e.SubMsg)
+}
+
+func AsBizError(err error) *BizErr {
+	if bizerr, ok := err.(*BizErr); ok && bizerr != nil {
+		return bizerr
+	}
+	return nil
 }

--- a/alipay/error_test.go
+++ b/alipay/error_test.go
@@ -1,0 +1,46 @@
+package alipay
+
+import (
+	"testing"
+)
+
+func TestBizErr_BizErrCheck(t *testing.T) {
+	bizErrRsp := ErrorResponse{
+		Code: "40004",
+		Msg:  "NOT_FOUND",
+	}
+	if bizErrCheck(bizErrRsp) == nil {
+		t.Fail()
+	}
+
+	noBizErrRsp := ErrorResponse{
+		Code: "10000",
+		Msg:  "SUCCEED",
+	}
+
+	if bizErrCheck(noBizErrRsp) != nil {
+		t.Fail()
+	}
+}
+
+func TestBizErr_AsBizError(t *testing.T) {
+	bizErrRsp := ErrorResponse{
+		Code: "40004",
+		Msg:  "NOT_FOUND",
+	}
+	noBizErrRsp := ErrorResponse{
+		Code: "10000",
+		Msg:  "SUCCEED",
+	}
+	var err error
+	err = bizErrCheck(bizErrRsp)
+	if bizErr := AsBizError(err); bizErr == nil {
+		t.Fail()
+	}
+
+	err = bizErrCheck(noBizErrRsp)
+	if bizErr := AsBizError(err); bizErr != nil {
+		t.Fail()
+	}
+
+}

--- a/alipay/model.go
+++ b/alipay/model.go
@@ -66,13 +66,6 @@ type UserPhone struct {
 	Mobile string `json:"mobile,omitempty"`
 }
 
-type ErrorResponse struct {
-	Code    string `json:"code"`
-	Msg     string `json:"msg"`
-	SubCode string `json:"sub_code,omitempty"`
-	SubMsg  string `json:"sub_msg,omitempty"`
-}
-
 // ===================================================
 type TradePayResponse struct {
 	Response     *TradePay `json:"alipay_trade_pay_response"`

--- a/alipay/model.go
+++ b/alipay/model.go
@@ -66,6 +66,13 @@ type UserPhone struct {
 	Mobile string `json:"mobile,omitempty"`
 }
 
+type ErrorResponse struct {
+	Code    string `json:"code"`
+	Msg     string `json:"msg"`
+	SubCode string `json:"sub_code,omitempty"`
+	SubMsg  string `json:"sub_msg,omitempty"`
+}
+
 // ===================================================
 type TradePayResponse struct {
 	Response     *TradePay `json:"alipay_trade_pay_response"`

--- a/alipay/payment_api.go
+++ b/alipay/payment_api.go
@@ -124,9 +124,8 @@ func (a *Client) TradeCreate(ctx context.Context, bm gopay.BodyMap) (aliRsp *Tra
 	if err = json.Unmarshal(bs, aliRsp); err != nil {
 		return nil, err
 	}
-	if aliRsp.Response != nil && aliRsp.Response.Code != "10000" {
-		info := aliRsp.Response
-		return aliRsp, fmt.Errorf(`{"code":"%s","msg":"%s","sub_code":"%s","sub_msg":"%s"}`, info.Code, info.Msg, info.SubCode, info.SubMsg)
+	if bizErr := bizErrCheck(aliRsp.Response.ErrorResponse); bizErr != nil {
+		return aliRsp, bizErr
 	}
 	signData, signDataErr := a.getSignData(bs, aliRsp.AlipayCertSn)
 	aliRsp.SignData = signData

--- a/alipay/payment_api.go
+++ b/alipay/payment_api.go
@@ -147,10 +147,6 @@ func (a *Client) TradeQuery(ctx context.Context, bm gopay.BodyMap) (aliRsp *Trad
 	if err = json.Unmarshal(bs, aliRsp); err != nil {
 		return nil, err
 	}
-	if aliRsp.Response != nil && aliRsp.Response.Code != "10000" {
-		info := aliRsp.Response
-		return aliRsp, fmt.Errorf(`{"code":"%s","msg":"%s","sub_code":"%s","sub_msg":"%s"}`, info.Code, info.Msg, info.SubCode, info.SubMsg)
-	}
 	signData, signDataErr := a.getSignData(bs, aliRsp.AlipayCertSn)
 	aliRsp.SignData = signData
 	return aliRsp, a.autoVerifySignByCert(aliRsp.Sign, signData, signDataErr)


### PR DESCRIPTION
**这个PR 包含了举例用途的代码修改  还不能合并**

将现有的ErrorResponse 从model.go 移动到了error.go(新增), 出于将要为其添加方法的考虑, 认为他不再只是一个model, 所以移出来了.

然后ErrorResponse 实现了error 的接口, 可以被当作error 返回

相关issues: #221 