### PR TITLE
feat: custom xlog to redirect log

### DIFF
--- a/pkg/xlog/log.go
+++ b/pkg/xlog/log.go
@@ -53,3 +53,19 @@ func Error(args ...interface{}) {
 func Errorf(format string, args ...interface{}) {
 	errLog.LogOut(nil, &format, args...)
 }
+
+func SetDebugLog(logger XLogger) {
+	debugLog = logger
+}
+
+func SetInfoLog(logger XLogger) {
+	infoLog = logger
+}
+
+func SetWarnLog(logger XLogger) {
+	warnLog = logger
+}
+
+func SetErrLog(logger XLogger) {
+	errLog = logger
+}


### PR DESCRIPTION
Don't know why remove xlog public setter [v1.5.74](https://github.com/go-pay/gopay/commit/f1c47485f9fe8e8f3ccd8ca5819f2c797aaffd7f), I need it to set with custom logger for redirecting log output