### PR TITLE
add: 添加 app 签约接口

### DIFF
--- a/alipay/member_api_test.go
+++ b/alipay/member_api_test.go
@@ -122,6 +122,41 @@ func TestUserAgreementTransfer(t *testing.T) {
 	xlog.Debug("aliRsp:", *aliRsp)
 }
 
+func TestUserAgreementPageSignInApp(t *testing.T) {
+	// 请求参数
+	bm := make(gopay.BodyMap)
+	bm.Set("personal_product_code", "CYCLE_PAY_AUTH_P")
+	bm.Set("product_code", "CYCLE_PAY_AUTH")
+	bm.Set("sign_scene", "INDUSTRY|EDU")
+	bm.Set("agreement_effect_type", "DIRECT")
+	bm.Set("notify_url", "https://yt-api.t.ergedd.com/api/v1/sign_notify/alipay")
+	bm.Set("external_agreement_no", "9bAduAd8uvkkU9GrCCw4jYCi64GOYiPI")
+
+	bm.SetBodyMap("period_rule_params", func(bm gopay.BodyMap) {
+		bm.Set("period_type", "MONTH")
+		bm.Set("period", 1)
+		bm.Set("execute_time", "2023-01-01")
+		bm.Set("single_amount", 0.01)
+	})
+	bm.SetBodyMap("access_params", func(ab gopay.BodyMap) {
+		ab.Set("channel", "ALIPAYAPP")
+	})
+
+	// 发起请求
+	link, err := client.UserAgreementPageSignInApp(ctx, bm)
+	xlog.Info(err)
+	if err != nil {
+		if bizErr, ok := IsBizError(err); ok {
+			xlog.Errorf("%+v", bizErr)
+			// do something
+			return
+		}
+		return
+	}
+
+	xlog.Debug("aliRsp:", link)
+}
+
 func TestUserTwostageCommonUse(t *testing.T) {
 	// 请求参数
 	bm := make(gopay.BodyMap)

--- a/doc/alipay.md
+++ b/doc/alipay.md
@@ -285,6 +285,7 @@ xlog.Infof("%+v", phone)
     * 身份认证开始认证（获取认证链接）: `client.UserCertifyOpenCertify()`
     * 身份认证记录查询: `client.UserCertifyOpenQuery()`
     * 支付宝个人协议页面签约接口: `client.UserAgreementPageSign()`
+    * 支付宝个人协议页面签约接口(App 专用,生成唤醒签约页面链接): `client.UserAgreementPageSignInApp()`
     * 支付宝个人代扣协议解约接口: `client.UserAgreementPageUnSign()`
     * 支付宝个人代扣协议查询接口: `client.UserAgreementQuery()`
     * 周期性扣款协议执行计划修改接口: `client.UserAgreementExecutionplanModify()`


### PR DESCRIPTION
1. 添加`PageExecute`用以只生成签名, 不发送请求. 和官方`SDK`命名一致
2. 添加`UserAgreementPageSignInApp`放在, 在`App`签约唤醒支付宝使用