### PR TITLE
添加支付宝资金账户资产查询接口返回参数：freeze_amount

### DIFF
--- a/alipay/model.go
+++ b/alipay/model.go
@@ -819,6 +819,7 @@ type FundAccountQueryResponse struct {
 type FundAccountQuery struct {
 	ErrorResponse
 	AvailableAmount string       `json:"available_amount,omitempty"`
+	FreezeAmount    string       `json:"freeze_amount,omitempty"`
 	ExtCardInfo     *ExtCardInfo `json:"ext_card_info,omitempty"`
 }
 


### PR DESCRIPTION
Add: 支付宝资金账户资产查询接口返回当前支付宝账户的实时冻结余额：freeze_amount 
https://opendocs.alipay.com/open/02byuq?scene=c76aa8f1c54e4b8b8ffecfafc4d3c31c