### PR TITLE
fix bug: [unmarshal error]: invalid character ')' after top-level value,

### DIFF
--- a/qq/oplatform_api.go
+++ b/qq/oplatform_api.go
@@ -102,8 +102,8 @@ func GetOpenId(ctx context.Context, accessToken string, lang ...string) (openid 
 	if err != nil {
 		return nil, err
 	}
-	bs = bytes.TrimLeft(bs, "callback(")
-	bs = bytes.TrimRight(bs, ");")
+	bs = bytes.ReplaceAll(bs, []byte("callback("), []byte(""))
+	bs = bytes.ReplaceAll(bs, []byte(");"), []byte(""))
 	err = json.Unmarshal(bs, openid)
 	if err != nil {
 		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, bs)


### PR DESCRIPTION
报错信息
`qq qqAuth.GetOpenId error [unmarshal error]: invalid character ')' after top-level value, bytes:  {"client_id":"101221111","openid":"9A12284F472F721xxx13E0307","unionid":"UID_C5444xxxxx4E9DBFxxx9DDC9"} );`

bs = bytes.TrimLeft(bs, "callback(")
bs = bytes.TrimRight(bs, ");") // mac 这句没问题，但是linux中就会报上面的错