### PR TITLE
fix: RoyaltyDetail 对象补充 detail_id 字段

### DIFF
--- a/alipay/merchant_api.go
+++ b/alipay/merchant_api.go
@@ -77,6 +77,29 @@ func (a *Client) TradeRelationBatchQuery(ctx context.Context, bm gopay.BodyMap) 
 	return aliRsp, a.autoVerifySignByCert(aliRsp.Sign, signData, signDataErr)
 }
 
+// alipay.trade.settle.confirm(统一收单确认结算接口)
+// 文档地址：https://opendocs.alipay.com/open/028xqy
+func (a *Client) TradeSettleConfirm(ctx context.Context, bm gopay.BodyMap) (aliRsp *TradeSettleConfirmResponse, err error) {
+	err = bm.CheckEmptyError("out_request_no", "trade_no")
+	if err != nil {
+		return nil, err
+	}
+	var bs []byte
+	if bs, err = a.doAliPay(ctx, bm, "alipay.trade.settle.confirm"); err != nil {
+		return nil, err
+	}
+	aliRsp = new(TradeSettleConfirmResponse)
+	if err = json.Unmarshal(bs, aliRsp); err != nil || aliRsp.Response == nil {
+		return nil, fmt.Errorf("[%w], bytes: %s", gopay.UnmarshalErr, string(bs))
+	}
+	if err = bizErrCheck(aliRsp.Response.ErrorResponse); err != nil {
+		return aliRsp, err
+	}
+	signData, signDataErr := a.getSignData(bs, aliRsp.AlipayCertSn)
+	aliRsp.SignData = signData
+	return aliRsp, a.autoVerifySignByCert(aliRsp.Sign, signData, signDataErr)
+}
+
 // alipay.trade.order.settle(统一收单交易结算接口)
 // 文档地址：https://opendocs.alipay.com/open/02j2bt
 func (a *Client) TradeOrderSettle(ctx context.Context, bm gopay.BodyMap) (aliRsp *TradeOrderSettleResponse, err error) {

--- a/alipay/model_merchant.go
+++ b/alipay/model_merchant.go
@@ -21,6 +21,13 @@ type TradeRelationBatchQueryResponse struct {
 	Sign         string                   `json:"sign"`
 }
 
+type TradeSettleConfirmResponse struct {
+	Response     *TradeOrderSettle `json:"alipay_trade_settle_confirm_response"`
+	AlipayCertSn string            `json:"alipay_cert_sn,omitempty"`
+	SignData     string            `json:"-"`
+	Sign         string            `json:"sign"`
+}
+
 type TradeOrderSettleResponse struct {
 	Response     *TradeOrderSettle `json:"alipay_trade_order_settle_response"`
 	AlipayCertSn string            `json:"alipay_cert_sn,omitempty"`

--- a/alipay/model_merchant.go
+++ b/alipay/model_merchant.go
@@ -86,6 +86,7 @@ type RoyaltyDetail struct {
 	TransInType   string `json:"trans_in_type"`
 	Amount        string `json:"amount"`
 	State         string `json:"state"`
+	DetailId      string `json:"detail_id"`
 	ErrorCode     string `json:"error_code"`
 	ErrorDesc     string `json:"error_desc"`
 }


### PR DESCRIPTION
补充分账查询结果的 RoyaltyDetail 对象的 detail_id 字段

详见文档  https://opendocs.alipay.com/open/02o6e0?pathHash=158daac5