### PR TITLE
微信支付消费者投诉新增对接接口

### DIFF
--- a/wechat/v3/media.go
+++ b/wechat/v3/media.go
@@ -1,14 +1,40 @@
 package wechat
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"net/http"
-
 	"github.com/go-pay/gopay"
 	"github.com/go-pay/gopay/pkg/util"
+	"net/http"
+	"net/url"
 )
+
+// 图片资源下载
+// Code = 0 is success
+// 商户文档：https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter10_2_18.shtml
+// 服务商文档：https://pay.weixin.qq.com/wiki/doc/apiv3_partner/apis/chapter10_2_18.shtml
+func (c *ClientV3) V3MediaDownloadImage(ctx context.Context, mediaUrl string) (resBody *bytes.Buffer, err error) {
+	urlInfo, err := url.Parse(mediaUrl)
+	if err != nil {
+		return nil, err
+	}
+	authorization, err := c.authorization(MethodGet, urlInfo.RequestURI(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, si, bs, err := c.doProdGet(ctx, urlInfo.RequestURI(), authorization)
+	defer res.Body.Close()
+
+	resBody = bytes.NewBuffer(bs)
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New(string(bs))
+	}
+	return resBody, c.verifySyncSign(si)
+}
 
 // 图片上传API
 // 注意：图片不能超过2MB

--- a/wechat/v3/model_complaint.go
+++ b/wechat/v3/model_complaint.go
@@ -115,13 +115,13 @@ type ComplaintNegotiationHistory struct {
 }
 
 type ComplaintNegotiationHistoryItem struct {
-	ComplaintMediaList []*ComplaintMediaList `json:"complaint_media_list,omitempty"` // 投诉资料列表
-	LogId              string                `json:"log_id"`                         // 操作流水号
-	Operator           string                `json:"operator"`                       // 当前投诉协商记录的操作人
-	OperateTime        string                `json:"operate_time"`                   // 当前投诉协商记录的操作时间
-	OperateType        string                `json:"operate_type"`                   // 当前投诉协商记录的操作类型
-	OperateDetails     string                `json:"operate_details"`                // 当前投诉协商记录的具体内容
-	ImageList          []string              `json:"image_list"`                     // 当前投诉协商记录提交的图片凭证（url格式），最多返回4张图片，url有效时间为1小时。如未查询到协商历史图片凭证，则返回空数组。
+	ComplaintMediaList *ComplaintMediaList `json:"complaint_media_list,omitempty"` // 投诉资料列表
+	LogId              string              `json:"log_id"`                         // 操作流水号
+	Operator           string              `json:"operator"`                       // 当前投诉协商记录的操作人
+	OperateTime        string              `json:"operate_time"`                   // 当前投诉协商记录的操作时间
+	OperateType        string              `json:"operate_type"`                   // 当前投诉协商记录的操作类型
+	OperateDetails     string              `json:"operate_details"`                // 当前投诉协商记录的具体内容
+	ImageList          []string            `json:"image_list"`                     // 当前投诉协商记录提交的图片凭证（url格式），最多返回4张图片，url有效时间为1小时。如未查询到协商历史图片凭证，则返回空数组。
 }
 
 type ComplaintNotifyUrl struct {


### PR DESCRIPTION
1.新增投诉信息中的图片下载查询接口；
2.修复投诉历史详情查询接口数据结构问题，媒体资源应该是一个数组类型；
上述问题已在项目调试过程中经过测试，没啥大问题OK，大佬可以帮忙看看。