### PR TITLE
fix[apple]: NewClient set isProd

### DIFF
--- a/apple/client.go
+++ b/apple/client.go
@@ -42,6 +42,7 @@ func NewClient(iss, bid, kid, privateKey string, isProd bool) (client *Client, e
 		bid:        bid,
 		kid:        kid,
 		privateKey: ecPrivateKey,
+		isProd:     isProd,
 	}
 	return client, nil
 }


### PR DESCRIPTION
解决初始化苹果支付 client 时未设置正式环境的问题