### PR TITLE
feat: 添加buyer_open_id

### DIFF
--- a/alipay/model_payment.go
+++ b/alipay/model_payment.go
@@ -182,6 +182,7 @@ type TradeQuery struct {
 	FundBillList        []*TradeFundBill `json:"fund_bill_list"`
 	StoreName           string           `json:"store_name,omitempty"`
 	BuyerUserId         string           `json:"buyer_user_id,omitempty"`
+	BuyerOpenId         string           `json:"buyer_open_id,omitempty"`
 	ChargeAmount        string           `json:"charge_amount,omitempty"`
 	ChargeFlags         string           `json:"charge_flags,omitempty"`
 	SettlementId        string           `json:"settlement_id,omitempty"`


### PR DESCRIPTION
TradeQuery添加buyer_open_id。
以OpenID形式接入Alipay，将使用buyer_open_id字段。
![259f7ae0879a2d751e1276503ffaa2d](https://github.com/go-pay/gopay/assets/42832734/167cb26e-a916-42b7-8eb1-d8e6c3dfaae3)
userid模式将弃用。
![fd9ba029c845b3a21481cc8ff831929](https://github.com/go-pay/gopay/assets/42832734/b7113e75-7d3e-4735-a548-b6044b5ecf0b)
