### PR TITLE
fix(apple): fix apple GetNotificationHistory api imp

### DIFF
--- a/apple/notification_v2.go
+++ b/apple/notification_v2.go
@@ -44,7 +44,12 @@ func DecodeSignedPayload(signedPayload string) (payload *NotificationV2Payload, 
 // rsp.NotificationHistory[x].SignedPayload use apple.DecodeSignedPayload() to decode
 // Doc: https://developer.apple.com/documentation/appstoreserverapi/get_notification_history
 func (c *Client) GetNotificationHistory(ctx context.Context, paginationToken string, bm gopay.BodyMap) (rsp *NotificationHistoryRsp, err error) {
-	path := getNotificationHistory + "?paginationToken=" + paginationToken
+	path := getNotificationHistory
+	// Note: Omit this parameter the first time you call this endpoint.
+	if paginationToken != "" {
+		path += "?paginationToken=" + paginationToken
+	}
+
 	res, bs, err := c.doRequestPost(ctx, path, bm)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
根据苹果文档要求，第一次调用不能传递paginationToken参数，所以做了处理。