### PR TITLE
根据官方最新文档说明调整字段Version Update notification_v2_model.go

### DIFF
--- a/apple/notification_v2_model.go
+++ b/apple/notification_v2_model.go
@@ -52,7 +52,7 @@ type NotificationV2Payload struct {
 	NotificationType    string `json:"notificationType"`
 	Subtype             string `json:"subtype"`
 	NotificationUUID    string `json:"notificationUUID"`
-	NotificationVersion string `json:"notificationVersion"`
+	Version             string `json:"version"`
 	Data                *Data  `json:"data"`
 }
 


### PR DESCRIPTION
根据官方最新文档说明，更新了通知版本NotificationVersion字段
由原来结构体
NotificationV2Payload.NotificationVersion   `json:notificationVersion`
调整为
NotificationV2Payload.Version    `json:version`