### PR TITLE
Apple d

### DIFF
--- a/apple/verify.go
+++ b/apple/verify.go
@@ -26,3 +26,19 @@ func VerifyReceipt(ctx context.Context, url, pwd, receipt string) (rsp *VerifyRe
 	}
 	return rsp, nil
 }
+
+// 非订阅类型不需要 Password
+// VerifyReceipt 请求APP Store 校验支付请求,实际测试时发现这个文档介绍的返回信息只有那个status==0表示成功可以用，其他的返回信息跟文档对不上
+// url：取 UrlProd 或 UrlSandbox
+// 文档：https://developer.apple.com/documentation/appstorereceipts/verifyreceipt
+func VerifyReceiptNoPassword(ctx context.Context, url, receipt string) (rsp *VerifyResponse, err error) {
+	req := &VerifyRequestNoPassword{Receipt: receipt}
+	rsp = new(VerifyResponse)
+	_, err = xhttp.NewClient().Type(xhttp.TypeJSON).Post(url).SendStruct(req).EndStruct(ctx, rsp)
+	if err != nil {
+		return nil, err
+	}
+	return rsp, nil
+}
+
+

--- a/apple/verify_model.go
+++ b/apple/verify_model.go
@@ -13,6 +13,16 @@ type VerifyRequest struct {
 	ExcludeOldTranscations bool `json:"exclude-old-transactions"`
 }
 
+// VerifyRequest 校验请求体  没有密钥的
+// https://developer.apple.com/documentation/appstorereceipts/requestbody
+type VerifyRequestNoPassword struct {
+	// Receipt app解析出的票据信息
+	Receipt string `json:"receipt-data"`
+
+	// ExcludeOldTranscations Set this value to true for the response to include only the latest renewal transaction for any subscriptions. Use this field only for app receipts that contain auto-renewable subscriptions.
+	ExcludeOldTranscations bool `json:"exclude-old-transactions"`
+}
+
 // VerifyResponse 校验响应体
 // https://developer.apple.com/documentation/appstorereceipts/responsebody
 type VerifyResponse struct {


### PR DESCRIPTION
消耗类型的 订单验证有时候不需要 password， 这个时候即使password 传空值  apple 那边返回 status=21004, 需要吧password完全从参数中去掉