### PR TITLE
paypal 在到期结束前的一半时间内，自动刷新token

### DIFF
--- a/paypal/client.go
+++ b/paypal/client.go
@@ -42,7 +42,7 @@ func NewClient(clientid, secret string, isProd bool) (client *Client, err error)
 	}
 	// 在到期结束前的一半时间内，自动刷新token
 	go func(token *AccessToken) {
-		ticker := time.NewTicker(time.Duration(token.ExpiresIn / 2))
+		ticker := time.NewTicker(time.Duration(token.ExpiresIn/2) * time.Second)
 		for {
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
上线后一段时间经常出现：errcode: 401, errmsg: {401 {"error":"invalid_token","error_description":"Access Token not found in cache"} 0x4007130d80 0x40001c37c0}

发现token从初始化client后 一直没做刷新，于是在 初始化client 时，开个协程，定期更新token