### PR TITLE
[Fix file upload method]: remove file upload biz content encrypt params

### DIFF
--- a/alipay/request.go
+++ b/alipay/request.go
@@ -53,12 +53,6 @@ func (a *Client) PostFileAliPayAPISelfV2(ctx context.Context, bm gopay.BodyMap, 
 			bm.Remove(k)
 			continue
 		}
-		// 对form内容字段进行加密
-		str := bm.GetString(k)
-		bm.Remove(k)
-		if signedData, err := a.getStrRsaSign(str, bm.GetString("sign_type")); err == nil {
-			bm.Set(k, signedData)
-		}
 	}
 
 	bm.Set("method", method)


### PR DESCRIPTION
Sorry，上次提交的时候文件上传&验签确实成功了，但是参数没有解析，又找了好久的文档，发现真实情况是：
本接口为文件上传类接口，与普通OpenAPI接口的入参构造格式不同，如果您没有使用官方SDK发起OpenAPI调用，自行构造HTTP请求时需注意以下事项：
1. 本接口使用multipart/form-data内容格式上传文本参数与文件，文件字段需传入filename文件名，并带扩展名（例如：Content-Disposition: form-data; name="file_content"; filename="example.png"），否则会提示图片类型为空。
2. 对于v2版本的协议，**本接口的业务请求参数没有封装在biz_content字段中，直接平铺到请求的body中**。

也就是说，对于业务参数不需要放到biz_content，也不需要加密处理，所以移除了参数加密的代码，详见这个文档：
https://opendocs.alipay.com/mini/510d4a72_alipay.merchant.item.file.upload