### PR TITLE
feat: specify proxy url for paypal client

### DIFF
--- a/paypal/access_token.go
+++ b/paypal/access_token.go
@@ -43,11 +43,11 @@ func (c *Client) goAuthRefreshToken() {
 // 文档：https://developer.paypal.com/docs/api/reference/get-an-access-token
 func (c *Client) GetAccessToken() (token *AccessToken, err error) {
 	var (
-		baseUrl = baseUrlProd
+		baseUrl = c.BaseUrlProd
 		url     string
 	)
 	if !c.IsProd {
-		baseUrl = baseUrlSandbox
+		baseUrl = c.BaseUrlSandbox
 	}
 	url = baseUrl + getAccessToken
 	// Authorization

--- a/paypal/access_token.go
+++ b/paypal/access_token.go
@@ -43,11 +43,11 @@ func (c *Client) goAuthRefreshToken() {
 // 文档：https://developer.paypal.com/docs/api/reference/get-an-access-token
 func (c *Client) GetAccessToken() (token *AccessToken, err error) {
 	var (
-		baseUrl = c.BaseUrlProd
+		baseUrl = c.baseUrlProd
 		url     string
 	)
 	if !c.IsProd {
-		baseUrl = c.BaseUrlSandbox
+		baseUrl = c.baseUrlSandbox
 	}
 	url = baseUrl + getAccessToken
 	// Authorization

--- a/paypal/client.go
+++ b/paypal/client.go
@@ -19,8 +19,8 @@ type Client struct {
 	ctx            context.Context
 	DebugSwitch    gopay.DebugSwitch
 	hc             *xhttp.Client
-	BaseUrlProd    string
-	BaseUrlSandbox string
+	baseUrlProd    string
+	baseUrlSandbox string
 }
 
 // NewClient 初始化PayPal支付客户端
@@ -35,8 +35,8 @@ func NewClient(clientid, secret string, isProd bool) (client *Client, err error)
 		ctx:            context.Background(),
 		DebugSwitch:    gopay.DebugOff,
 		hc:             xhttp.NewClient(),
-		BaseUrlProd:    baseUrlProd,
-		BaseUrlSandbox: baseUrlSandbox,
+		baseUrlProd:    baseUrlProd,
+		baseUrlSandbox: baseUrlSandbox,
 	}
 	_, err = client.GetAccessToken()
 	if err != nil {
@@ -54,10 +54,10 @@ func (c *Client) SetBodySize(sizeMB int) {
 	}
 }
 
-// SetBaseUrl 设置指定的BaseUrl
+// SetProxyUrl 设置代理 Url
 // 使用场景：
 // 	1. 大陆直接调用 PayPal 接口响应较慢，可以在第三地例如硅谷部署代理服务器来加速请求
-func (c *Client) SetBaseUrl(specBaseUrlProd, specBaseUrlSandbox string) {
-	c.BaseUrlProd = specBaseUrlProd
-	c.BaseUrlSandbox = specBaseUrlSandbox
+func (c *Client) SetProxyUrl(proxyUrlProd, proxyUrlSandbox string) {
+	c.baseUrlProd = proxyUrlProd
+	c.baseUrlSandbox = proxyUrlSandbox
 }

--- a/paypal/client.go
+++ b/paypal/client.go
@@ -10,15 +10,17 @@ import (
 
 // Client PayPal支付客户端
 type Client struct {
-	Clientid    string
-	Secret      string
-	Appid       string
-	AccessToken string
-	ExpiresIn   int
-	IsProd      bool
-	ctx         context.Context
-	DebugSwitch gopay.DebugSwitch
-	hc          *xhttp.Client
+	Clientid       string
+	Secret         string
+	Appid          string
+	AccessToken    string
+	ExpiresIn      int
+	IsProd         bool
+	ctx            context.Context
+	DebugSwitch    gopay.DebugSwitch
+	hc             *xhttp.Client
+	BaseUrlProd    string
+	BaseUrlSandbox string
 }
 
 // NewClient 初始化PayPal支付客户端
@@ -27,12 +29,14 @@ func NewClient(clientid, secret string, isProd bool) (client *Client, err error)
 		return nil, gopay.MissPayPalInitParamErr
 	}
 	client = &Client{
-		Clientid:    clientid,
-		Secret:      secret,
-		IsProd:      isProd,
-		ctx:         context.Background(),
-		DebugSwitch: gopay.DebugOff,
-		hc:          xhttp.NewClient(),
+		Clientid:       clientid,
+		Secret:         secret,
+		IsProd:         isProd,
+		ctx:            context.Background(),
+		DebugSwitch:    gopay.DebugOff,
+		hc:             xhttp.NewClient(),
+		BaseUrlProd:    baseUrlProd,
+		BaseUrlSandbox: baseUrlSandbox,
 	}
 	_, err = client.GetAccessToken()
 	if err != nil {
@@ -48,4 +52,12 @@ func (c *Client) SetBodySize(sizeMB int) {
 	if sizeMB > 0 {
 		c.hc.SetBodySize(sizeMB)
 	}
+}
+
+// SetBaseUrl 设置指定的BaseUrl
+// 使用场景：
+// 	1. 大陆直接调用 PayPal 接口响应较慢，可以在第三地例如硅谷部署代理服务器来加速请求
+func (c *Client) SetBaseUrl(specBaseUrlProd, specBaseUrlSandbox string) {
+	c.BaseUrlProd = specBaseUrlProd
+	c.BaseUrlSandbox = specBaseUrlSandbox
 }

--- a/paypal/request.go
+++ b/paypal/request.go
@@ -10,9 +10,9 @@ import (
 )
 
 func (c *Client) doPayPalGet(ctx context.Context, uri string) (res *http.Response, bs []byte, err error) {
-	var url = c.BaseUrlProd + uri
+	var url = c.baseUrlProd + uri
 	if !c.IsProd {
-		url = c.BaseUrlSandbox + uri
+		url = c.baseUrlSandbox + uri
 	}
 	req := c.hc.Req() // default json
 	req.Header.Add(HeaderAuthorization, AuthorizationPrefixBearer+c.AccessToken)
@@ -33,9 +33,9 @@ func (c *Client) doPayPalGet(ctx context.Context, uri string) (res *http.Respons
 }
 
 func (c *Client) doPayPalPost(ctx context.Context, bm gopay.BodyMap, path string) (res *http.Response, bs []byte, err error) {
-	var url = c.BaseUrlProd + path
+	var url = c.baseUrlProd + path
 	if !c.IsProd {
-		url = c.BaseUrlSandbox + path
+		url = c.baseUrlSandbox + path
 	}
 	req := c.hc.Req() // default json
 	req.Header.Add(HeaderAuthorization, AuthorizationPrefixBearer+c.AccessToken)
@@ -57,9 +57,9 @@ func (c *Client) doPayPalPost(ctx context.Context, bm gopay.BodyMap, path string
 }
 
 func (c *Client) doPayPalPut(ctx context.Context, bm gopay.BodyMap, path string) (res *http.Response, bs []byte, err error) {
-	var url = c.BaseUrlProd + path
+	var url = c.baseUrlProd + path
 	if !c.IsProd {
-		url = c.BaseUrlSandbox + path
+		url = c.baseUrlSandbox + path
 	}
 	req := c.hc.Req() // default json
 	req.Header.Add(HeaderAuthorization, AuthorizationPrefixBearer+c.AccessToken)
@@ -81,9 +81,9 @@ func (c *Client) doPayPalPut(ctx context.Context, bm gopay.BodyMap, path string)
 }
 
 func (c *Client) doPayPalPatch(ctx context.Context, patchs []*Patch, path string) (res *http.Response, bs []byte, err error) {
-	var url = c.BaseUrlProd + path
+	var url = c.baseUrlProd + path
 	if !c.IsProd {
-		url = c.BaseUrlSandbox + path
+		url = c.baseUrlSandbox + path
 	}
 	req := c.hc.Req() // default json
 	req.Header.Add(HeaderAuthorization, AuthorizationPrefixBearer+c.AccessToken)
@@ -106,9 +106,9 @@ func (c *Client) doPayPalPatch(ctx context.Context, patchs []*Patch, path string
 }
 
 func (c *Client) doPayPalDelete(ctx context.Context, path string) (res *http.Response, bs []byte, err error) {
-	var url = c.BaseUrlProd + path
+	var url = c.baseUrlProd + path
 	if !c.IsProd {
-		url = c.BaseUrlSandbox + path
+		url = c.baseUrlSandbox + path
 	}
 	req := c.hc.Req() // default json
 	req.Header.Add(HeaderAuthorization, AuthorizationPrefixBearer+c.AccessToken)

--- a/paypal/request.go
+++ b/paypal/request.go
@@ -10,9 +10,9 @@ import (
 )
 
 func (c *Client) doPayPalGet(ctx context.Context, uri string) (res *http.Response, bs []byte, err error) {
-	var url = baseUrlProd + uri
+	var url = c.BaseUrlProd + uri
 	if !c.IsProd {
-		url = baseUrlSandbox + uri
+		url = c.BaseUrlSandbox + uri
 	}
 	req := c.hc.Req() // default json
 	req.Header.Add(HeaderAuthorization, AuthorizationPrefixBearer+c.AccessToken)
@@ -33,9 +33,9 @@ func (c *Client) doPayPalGet(ctx context.Context, uri string) (res *http.Respons
 }
 
 func (c *Client) doPayPalPost(ctx context.Context, bm gopay.BodyMap, path string) (res *http.Response, bs []byte, err error) {
-	var url = baseUrlProd + path
+	var url = c.BaseUrlProd + path
 	if !c.IsProd {
-		url = baseUrlSandbox + path
+		url = c.BaseUrlSandbox + path
 	}
 	req := c.hc.Req() // default json
 	req.Header.Add(HeaderAuthorization, AuthorizationPrefixBearer+c.AccessToken)
@@ -57,9 +57,9 @@ func (c *Client) doPayPalPost(ctx context.Context, bm gopay.BodyMap, path string
 }
 
 func (c *Client) doPayPalPut(ctx context.Context, bm gopay.BodyMap, path string) (res *http.Response, bs []byte, err error) {
-	var url = baseUrlProd + path
+	var url = c.BaseUrlProd + path
 	if !c.IsProd {
-		url = baseUrlSandbox + path
+		url = c.BaseUrlSandbox + path
 	}
 	req := c.hc.Req() // default json
 	req.Header.Add(HeaderAuthorization, AuthorizationPrefixBearer+c.AccessToken)
@@ -81,9 +81,9 @@ func (c *Client) doPayPalPut(ctx context.Context, bm gopay.BodyMap, path string)
 }
 
 func (c *Client) doPayPalPatch(ctx context.Context, patchs []*Patch, path string) (res *http.Response, bs []byte, err error) {
-	var url = baseUrlProd + path
+	var url = c.BaseUrlProd + path
 	if !c.IsProd {
-		url = baseUrlSandbox + path
+		url = c.BaseUrlSandbox + path
 	}
 	req := c.hc.Req() // default json
 	req.Header.Add(HeaderAuthorization, AuthorizationPrefixBearer+c.AccessToken)
@@ -106,9 +106,9 @@ func (c *Client) doPayPalPatch(ctx context.Context, patchs []*Patch, path string
 }
 
 func (c *Client) doPayPalDelete(ctx context.Context, path string) (res *http.Response, bs []byte, err error) {
-	var url = baseUrlProd + path
+	var url = c.BaseUrlProd + path
 	if !c.IsProd {
-		url = baseUrlSandbox + path
+		url = c.BaseUrlSandbox + path
 	}
 	req := c.hc.Req() // default json
 	req.Header.Add(HeaderAuthorization, AuthorizationPrefixBearer+c.AccessToken)


### PR DESCRIPTION
### 改动
1. paypal.Client 新增方法 `SetProxyUrl` 来指定 paypal 代理 URL，用作大陆地区加速请求