### PR TITLE
Update  Apple Refunded Transaction  revocationReason

### DIFF
--- a/apple/transaction_model.go
+++ b/apple/transaction_model.go
@@ -40,7 +40,7 @@ type TransactionsItem struct {
 	PurchaseDate                int64  `json:"purchaseDate"`
 	Quantity                    int    `json:"quantity"`
 	RevocationDate              int64  `json:"revocationDate"`
-	RevocationReason            string `json:"revocationReason"`
+	RevocationReason            int `json:"revocationReason"`
 	SignedDate                  int64  `json:"signedDate"`
 	Storefront                  string `json:"storefront"`
 	StorefrontId                string `json:"storefrontId"`


### PR DESCRIPTION
fix bug:  apple refunded transaction  revocationReason type should be  int32

https://developer.apple.com/documentation/appstoreserverapi/revocationreason