### PR TITLE
fix(paypal): fulfill paypal order authorize response model

### DIFF
--- a/paypal/client.go
+++ b/paypal/client.go
@@ -73,3 +73,8 @@ func (c *Client) SetProxyUrl(proxyUrlProd, proxyUrlSandbox string) {
 	c.baseUrlProd = proxyUrlProd
 	c.baseUrlSandbox = proxyUrlSandbox
 }
+
+// SetHttpClient 设置自定义的xhttp.Client
+func (c *Client) SetHttpClient(client *xhttp.Client) {
+	c.hc = client
+}

--- a/paypal/model.go
+++ b/paypal/model.go
@@ -467,7 +467,26 @@ type Payments struct {
 }
 
 type Authorization struct {
-	ProcessorResponse *Processor `json:"processor_response,omitempty"`
+	Id                          string                       `json:"id,omitempty"`
+	Status                      string                       `json:"status,omitempty"` // CREATED、CAPTURED、DENIED、PARTIALLY_CAPTURED、VOIDED、PENDING
+	StatusDetails               *StatusDetails               `json:"status_details,omitempty"`
+	InvoiceId                   string                       `json:"invoice_id,omitempty"`
+	CustomId                    string                       `json:"custom_id,omitempty"`
+	Links                       []*Link                      `json:"links,omitempty"`
+	Amount                      *Amount                      `json:"amount"`
+	NetworkTransactionReference *NetworkTransactionReference `json:"network_transaction_reference"`
+	SellerProtection            *SellerProtection            `json:"seller_protection,omitempty"`
+	ExpirationTime              string                       `json:"expiration_time,omitempty"`
+	CreateTime                  string                       `json:"create_time,omitempty"`
+	UpdateTime                  string                       `json:"update_time,omitempty"`
+	ProcessorResponse           *Processor                   `json:"processor_response,omitempty"`
+}
+
+type NetworkTransactionReference struct {
+	Id                      string `json:"id"`
+	Date                    string `json:"date"`
+	AcquirerReferenceNumber string `json:"acquirer_reference_number"`
+	Network                 string `json:"network"`
 }
 
 type Processor struct {

--- a/paypal/order_test.go
+++ b/paypal/order_test.go
@@ -20,6 +20,7 @@ func TestCreateOrder(t *testing.T) {
 	pus = append(pus, item)
 
 	bm := make(gopay.BodyMap)
+	// can be AUTHORIZE
 	bm.Set("intent", "CAPTURE").
 		Set("purchase_units", pus).
 		SetBodyMap("application_context", func(b gopay.BodyMap) {
@@ -131,6 +132,9 @@ func TestOrderAuthorize(t *testing.T) {
 			xlog.Debugf("ppRsp.Response.PurchaseUnit.Shipping.Address: %+v", v.Shipping.Address)
 		}
 		xlog.Debugf("ppRsp.Response.PurchaseUnit.Description: %+v", v.Description)
+		if v.Payments != nil && v.Payments.Authorizations != nil {
+			xlog.Debugf("ppRsp.Response.PurchaseUnit.Payments.Authorizations: %+v", v.Payments.Authorizations)
+		}
 	}
 	for _, v := range ppRsp.Response.Links {
 		xlog.Debugf("ppRsp.Response.Links: %+v", v)


### PR DESCRIPTION
1. 丰富 paypal order 的授权接口返回值: 以便获取 AuthorizationId 进行后续操作
2. 相关 Issue https://github.com/go-pay/gopay/issues/402