### PR TITLE
feat: paypal client with http client option

### DIFF
--- a/paypal/client.go
+++ b/paypal/client.go
@@ -64,6 +64,13 @@ func WithProxyUrl(proxyUrlProd, proxyUrlSandbox string) Option {
 	}
 }
 
+// WithHttpClient 设置自定义的xhttp.Client
+func WithHttpClient(client *xhttp.Client) Option {
+	return func(c *Client) {
+		c.hc = client
+	}
+}
+
 // SetBodySize 设置http response body size(MB)
 func (c *Client) SetBodySize(sizeMB int) {
 	if sizeMB > 0 {


### PR DESCRIPTION
由于NewClient时就会执行GetAccessToken函数，在阿里云国内服务器下会连接失败，想要使用http代理就需要在NewClient时指定HttpClient option。