### PR TITLE
Feat/paypal 新增payment method token API

### DIFF
--- a/paypal/client_test.go
+++ b/paypal/client_test.go
@@ -19,13 +19,14 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	xlog.SetLevel(xlog.DebugLevel)
 	client, err = NewClient(Clientid, Secret, false)
 	if err != nil {
 		xlog.Error(err)
 		return
 	}
 	// 打开Debug开关，输出日志
-	client.DebugSwitch = gopay.DebugOff
+	client.DebugSwitch = gopay.DebugOn
 
 	xlog.Debugf("Appid: %s", client.Appid)
 	xlog.Debugf("AccessToken: %s", client.AccessToken)

--- a/paypal/constant.go
+++ b/paypal/constant.go
@@ -71,4 +71,12 @@ const (
 	deleteWebhook          = "/v1/notifications/webhooks/%s"              // webhook_id 删除webhook DELETE
 	verifyWebhookSignature = "/v1/notifications/verify-webhook-signature" //webhook消息验签
 	showWebhookEventDetail = "/v1/notifications/webhooks-events/%s"       // webhook_id 获取webhook-event详情 GET
+
+	// payment method tokens相关
+	createPaymentToken   = "/v3/vault/payment-tokens"    // 创建支付方式token POST
+	paymentTokenList     = "/v3/vault/payment-tokens"    // 获取支付方式token列表 GET
+	retrievePaymentToken = "/v3/vault/payment-tokens/%s" // 获取支付方式token详情 GET
+	deletePaymentToken   = "/v3/vault/payment-tokens/%s" // 删除支付方式token DELETE
+	createSetupToken     = "/v3/vault/setup-tokens"      // 创建支付方式token POST
+	retrieveSetupToken   = "/v3/vault/setup-tokens/%s"   // 获取支付方式token详情 GET
 )

--- a/paypal/model.go
+++ b/paypal/model.go
@@ -229,6 +229,41 @@ type InvoiceTemplateUpdateRsp struct {
 	Response      *Template      `json:"response,omitempty"`
 }
 
+type PaymentTokenCreateRsp struct {
+	Code          int                  `json:"-"`
+	Error         string               `json:"-"`
+	ErrorResponse *ErrorResponse       `json:"-"`
+	Response      *PaymentMethodDetail `json:"response,omitempty"`
+}
+
+type PaymentTokenListRsp struct {
+	Code          int                `json:"-"`
+	Error         string             `json:"-"`
+	ErrorResponse *ErrorResponse     `json:"-"`
+	Response      *PaymentTokensList `json:"response,omitempty"`
+}
+
+type PaymentTokenDetailRsp struct {
+	Code          int                  `json:"-"`
+	Error         string               `json:"-"`
+	ErrorResponse *ErrorResponse       `json:"-"`
+	Response      *PaymentMethodDetail `json:"response,omitempty"`
+}
+
+type PaymentSetupTokenCreateRsp struct {
+	Code          int                      `json:"-"`
+	Error         string                   `json:"-"`
+	ErrorResponse *ErrorResponse           `json:"-"`
+	Response      *PaymentSetupTokenDetail `json:"response,omitempty"`
+}
+
+type PaymentSetupTokenDetailRsp struct {
+	Code          int                      `json:"-"`
+	Error         string                   `json:"-"`
+	ErrorResponse *ErrorResponse           `json:"-"`
+	Response      *PaymentSetupTokenDetail `json:"response,omitempty"`
+}
+
 // ==================================分割==================================
 
 type Patch struct {
@@ -294,7 +329,13 @@ type PaypalVault struct {
 }
 
 type PaypalCustomer struct {
-	ID string `json:"id"`
+	ID         string         `json:"id"`
+	Phones     []*PhoneDetail `json:"phones"`
+	WebsiteUrl string         `json:"website_url"`
+	Company    string         `json:"company"`
+	Name       *Name          `json:"name"`
+	Email      string         `json:"email"`
+	Links      []*Link        `json:"links,omitempty"`
 }
 
 type PaypalLink struct {
@@ -686,6 +727,30 @@ type NetAmountBreakdown struct {
 	PayableAmount   *Amount       `json:"payable_amount,omitempty"`
 	ConvertedAmount *Amount       `json:"converted_amount,omitempty"`
 	ExchangeRate    *ExchangeRate `json:"exchange_rate,omitempty"`
+}
+
+type PaymentMethodDetail struct {
+	Id            string          `json:"id,omitempty"`
+	PaymentSource *PaymentSource  `json:"payment_source,omitempty"`
+	Customer      *PaypalCustomer `json:"customer,omitempty"`
+	Links         []*Link         `json:"links,omitempty"`
+}
+
+type PaymentTokensList struct {
+	TotalItems    int                    `json:"total_items,omitempty"`
+	TotalPages    int                    `json:"total_pages,omitempty"`
+	PaymentTokens []*PaymentMethodDetail `json:"payment_tokens,omitempty"`
+	Links         []*Link                `json:"links,omitempty"`
+	Customer      *PaypalCustomer        `json:"customer,omitempty"`
+}
+
+type PaymentSetupTokenDetail struct {
+	PaymentSource *PaymentSource  `json:"payment_source,omitempty"`
+	Links         []*Link         `json:"links,omitempty"`
+	Id            string          `json:"id,omitempty"`
+	Ordinal       int             `json:"ordinal,omitempty"`
+	Customer      *PaypalCustomer `json:"customer,omitempty"`
+	Status        string          `json:"status,omitempty"`
 }
 
 // =============== V1 API Payout ==================================

--- a/paypal/payment_token.go
+++ b/paypal/payment_token.go
@@ -1,0 +1,158 @@
+package paypal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/go-pay/gopay"
+)
+
+// CreatePaymentToken creates a payment token.
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/payment-tokens/v3/#payment-tokens_create
+func (c *Client) CreatePaymentToken(ctx context.Context, bm gopay.BodyMap) (ppRsp *PaymentTokenCreateRsp, err error) {
+	if err = bm.CheckEmptyError("payment_source"); err != nil {
+		return nil, err
+	}
+	res, bs, err := c.doPayPalPost(ctx, bm, createPaymentToken)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &PaymentTokenCreateRsp{Code: Success}
+	ppRsp.Response = new(PaymentMethodDetail)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusCreated && res.StatusCode != http.StatusOK {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, err
+}
+
+// ListAllPaymentTokens lists all payment tokens.
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/payment-tokens/v3/#customer_payment-tokens_get
+func (c *Client) ListAllPaymentTokens(ctx context.Context, query gopay.BodyMap) (ppRsp *PaymentTokenListRsp, err error) {
+	uri := paymentTokenList + "?" + query.EncodeURLParams()
+	res, bs, err := c.doPayPalGet(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &PaymentTokenListRsp{Code: Success}
+	ppRsp.Response = new(PaymentTokensList)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusOK {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, err
+}
+
+// RetrievePaymentToken retrieves a payment token.
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/payment-tokens/v3/#payment-tokens_get
+func (c *Client) RetrievePaymentToken(ctx context.Context, id string) (ppRsp *PaymentTokenDetailRsp, err error) {
+	if id == gopay.NULL {
+		return nil, errors.New("id is empty")
+	}
+	uri := fmt.Sprintf(retrievePaymentToken, id)
+	res, bs, err := c.doPayPalGet(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &PaymentTokenDetailRsp{Code: Success}
+	ppRsp.Response = new(PaymentMethodDetail)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusOK {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, err
+}
+
+// DeletePaymentToken deletes a payment token.
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/payment-tokens/v3/#payment-tokens_delete
+func (c *Client) DeletePaymentToken(ctx context.Context, id string) (ppRsp *EmptyRsp, err error) {
+	if id == gopay.NULL {
+		return nil, errors.New("id is empty")
+	}
+	uri := fmt.Sprintf(deletePaymentToken, id)
+	res, bs, err := c.doPayPalDelete(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &EmptyRsp{Code: Success}
+	if res.StatusCode != http.StatusNoContent {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, err
+}
+
+// CreateSetupToken creates a setup token.
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/payment-tokens/v3/#setup-tokens_create
+func (c *Client) CreateSetupToken(ctx context.Context, bm gopay.BodyMap) (ppRsp *PaymentSetupTokenCreateRsp, err error) {
+	if err = bm.CheckEmptyError("payment_source"); err != nil {
+		return nil, err
+	}
+	res, bs, err := c.doPayPalPost(ctx, bm, createSetupToken)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &PaymentSetupTokenCreateRsp{Code: Success}
+	ppRsp.Response = new(PaymentSetupTokenDetail)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusCreated && res.StatusCode != http.StatusOK {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, err
+}
+
+// RetrieveSetupToken retrieves a setup token.
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/payment-tokens/v3/#setup-tokens_get
+func (c *Client) RetrieveSetupToken(ctx context.Context, id string) (ppRsp *PaymentSetupTokenCreateRsp, err error) {
+	if id == gopay.NULL {
+		return nil, errors.New("id is empty")
+	}
+	uri := fmt.Sprintf(retrieveSetupToken, id)
+	res, bs, err := c.doPayPalGet(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &PaymentSetupTokenCreateRsp{Code: Success}
+	ppRsp.Response = new(PaymentSetupTokenDetail)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusOK {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, err
+}

--- a/paypal/payment_token_test.go
+++ b/paypal/payment_token_test.go
@@ -1,0 +1,143 @@
+package paypal
+
+import (
+	"testing"
+
+	"github.com/go-pay/gopay"
+	"github.com/go-pay/xlog"
+)
+
+func TestPaymentSetupTokenCreate(t *testing.T) {
+	bm := make(gopay.BodyMap)
+
+	bm.SetBodyMap("payment_source", func(b1 gopay.BodyMap) {
+		b1.SetBodyMap("paypal", func(b3 gopay.BodyMap) {
+			b3.SetBodyMap("experience_context", func(b4 gopay.BodyMap) {
+				b4.Set("shipping_preference", "SET_PROVIDED_ADDRESS").
+					Set("payment_method_preference", "IMMEDIATE_PAYMENT_REQUIRED").
+					Set("brand_name", "gopay").
+					Set("return_url", "https://example.com/returnUrl").
+					Set("cancel_url", "https://example.com/cancelUrl")
+			}).
+				Set("permit_multiple_payment_tokens", false).
+				Set("usage_pattern", "IMMEDIATE").
+				Set("usage_type", "MERCHANT").
+				Set("customer_type", "CONSUMER")
+		})
+	})
+	bm.SetBodyMap("customer", func(b2 gopay.BodyMap) {
+		b2.Set("id", "1234567890")
+	})
+
+	xlog.Debug("bm: ", bm.JsonBody())
+
+	ppRsp, err := client.CreateSetupToken(ctx, bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Response: %+v", ppRsp.Response)
+
+	for _, v := range ppRsp.Response.Links {
+		xlog.Debugf("ppRsp.Response.Links: %+v", v)
+	}
+}
+
+func TestRetrieveSetupToken(t *testing.T) {
+	ppRsp, err := client.RetrieveSetupToken(ctx, "5CS813092M1570432")
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Response: %+v", ppRsp.Response)
+}
+
+func TestListAllPaymentTokens(t *testing.T) {
+	bm := make(gopay.BodyMap)
+	bm.Set("customer_id", "1234567890").
+		Set("total_required", true)
+
+	ppRsp, err := client.ListAllPaymentTokens(ctx, bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Response: %+v", ppRsp.Response)
+}
+
+func TestRetrievePaymentToken(t *testing.T) {
+	ppRsp, err := client.RetrievePaymentToken(ctx, "5CS813092M1570432")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Response: %+v", ppRsp.Response)
+}
+
+func TestCreatePaymentToken(t *testing.T) {
+	bm := make(gopay.BodyMap)
+
+	bm.SetBodyMap("payment_source", func(b1 gopay.BodyMap) {
+		b1.SetBodyMap("token", func(b2 gopay.BodyMap) {
+			b2.Set("id", "5CS813092M1570432").
+				Set("type", "SETUP_TOKEN")
+		})
+	})
+
+	ppRsp, err := client.CreatePaymentToken(ctx, bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Response: %+v", ppRsp.Response)
+}
+
+func TestDeletePaymentToken(t *testing.T) {
+	ppRsp, err := client.DeletePaymentToken(ctx, "5CS813092M1570432")
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+}

--- a/paypal/payout.go
+++ b/paypal/payout.go
@@ -94,7 +94,7 @@ func (c *Client) ShowPayoutItemDetails(ctx context.Context, payoutItemId string)
 // 取消批量支付中收款人无PayPal账号的项目（Cancel Unclaimed Payout Item）
 // Code = 0 is success
 // 文档：https://developer.paypal.com/docs/api/payments.payouts-batch/v1/#payouts-item_cancel
-func (c Client) CancelUnclaimedPayoutItem(ctx context.Context, payoutItemId string) (ppRsp *CancelUnclaimedPayoutItemRsp, err error) {
+func (c *Client) CancelUnclaimedPayoutItem(ctx context.Context, payoutItemId string) (ppRsp *CancelUnclaimedPayoutItemRsp, err error) {
 	if payoutItemId == gopay.NULL {
 		return nil, errors.New("payout_item_id is empty")
 	}

--- a/paypal/payout.go
+++ b/paypal/payout.go
@@ -68,7 +68,7 @@ func (c *Client) ShowPayoutBatchDetails(ctx context.Context, payoutBatchId strin
 // 批量支出项目详情（Show Payout Item Details）
 // Code = 0 is success
 // 文档：https://developer.paypal.com/docs/api/payments.payouts-batch/v1/#payouts-item_get
-func (c Client) ShowPayoutItemDetails(ctx context.Context, payoutItemId string) (ppRsp *PayoutItemDetailRsp, err error) {
+func (c *Client) ShowPayoutItemDetails(ctx context.Context, payoutItemId string) (ppRsp *PayoutItemDetailRsp, err error) {
 	if payoutItemId == gopay.NULL {
 		return nil, errors.New("payout_item_id is empty")
 	}


### PR DESCRIPTION
1.新增payment method token API
2.paypal增加自动刷新Token选项,用以支持client每次调用都需要重新生成的场景。解决该场景下开启自动刷新token协程可能出现的内存泄漏问题以及错误
3.paypal client代码修正Struct Client has methods on both value and pointer receivers警告