### PR TITLE
增加paypal的产品、计划、订阅 接口

### DIFF
--- a/paypal/constant.go
+++ b/paypal/constant.go
@@ -38,6 +38,9 @@ const (
 
 	// 订阅相关
 	subscriptionCreate = "/v1/billing/plans" // 创建订阅 POST
+	subscriptionList   = "/v1/billing/plans"
+	subscriptionDetail = "/v1/billing/plans/%s" // plan_id 订阅详情 GET
+	subscriptionUpdate = "/v1/billing/plans/%s" // plan_id 更新订阅 PATCH
 
 	// 发票 Invoices 相关
 	generateInvoiceNumber      = "/v2/invoicing/generate-next-invoice-number" // 生成发票号码 POST

--- a/paypal/constant.go
+++ b/paypal/constant.go
@@ -79,4 +79,10 @@ const (
 	deletePaymentToken   = "/v3/vault/payment-tokens/%s" // 删除支付方式token DELETE
 	createSetupToken     = "/v3/vault/setup-tokens"      // 创建支付方式token POST
 	retrieveSetupToken   = "/v3/vault/setup-tokens/%s"   // 获取支付方式token详情 GET
+
+	// product 产品相关
+	productCreate = "/v1/catalogs/products"
+	productList   = "/v1/catalogs/products"
+	productDetail = "/v1/catalogs/products/%s" // product_id 产品详情 GET
+	productUpdate = "/v1/catalogs/products/%s" // product_id 更新产品 PATCH
 )

--- a/paypal/constant.go
+++ b/paypal/constant.go
@@ -37,10 +37,16 @@ const (
 	cancelUnclaimedPayoutItem = "/v1/payments/payouts-item/%s/cancel" // payout_item_id 取消支出项目 POST
 
 	// 订阅相关
-	subscriptionCreate = "/v1/billing/plans" // 创建订阅 POST
-	subscriptionList   = "/v1/billing/plans"
-	subscriptionDetail = "/v1/billing/plans/%s" // plan_id 订阅详情 GET
-	subscriptionUpdate = "/v1/billing/plans/%s" // plan_id 更新订阅 PATCH
+	planCreate               = "/v1/billing/plans" // 创建订阅 POST
+	planList                 = "/v1/billing/plans"
+	planDetail               = "/v1/billing/plans/%s" // plan_id 计划详情 GET
+	planUpdate               = "/v1/billing/plans/%s" // plan_id 更新计划 PATCH
+	subscriptionCreate       = "/v1/billing/subscriptions"
+	subscriptionDetail       = "/v1/billing/subscriptions/%s"              // subscription_id 订阅详情 GET
+	subscriptionSuspend      = "/v1/billing/subscriptions/%s/suspend"      // subscription_id 暂停订阅 GET
+	subscriptionCancel       = "/v1/billing/subscriptions/%s/cancel"       // subscription_id 取消订阅 GET
+	subscriptionActivate     = "/v1/billing/subscriptions/%s/activate"     // subscription_id 激活订阅 GET
+	subscriptionTransactions = "/v1/billing/subscriptions/%s/transactions" // subscription_id 激活订阅 GET
 
 	// 发票 Invoices 相关
 	generateInvoiceNumber      = "/v2/invoicing/generate-next-invoice-number" // 生成发票号码 POST

--- a/paypal/model.go
+++ b/paypal/model.go
@@ -882,6 +882,53 @@ type BillingDetail struct {
 	Links       []*Link `json:"links"`
 }
 
+type BillingListRsp struct {
+	Code          int            `json:"-"`
+	Error         string         `json:"-"`
+	ErrorResponse *ErrorResponse `json:"-"`
+	Response      *BillingPlans  `json:"response,omitempty"`
+}
+
+type BillingPlans struct {
+	Plans []Plan  `json:"plans"`
+	Links []*Link `json:"links,omitempty"`
+}
+
+type Plan struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Status      string  `json:"status"`
+	Description string  `json:"description"`
+	UsageType   string  `json:"usage_type"`
+	CreateTime  string  `json:"create_time"`
+	Links       []*Link `json:"links,omitempty"`
+}
+
+type PlanDetailRsp struct {
+	Code          int            `json:"-"`
+	Error         string         `json:"-"`
+	ErrorResponse *ErrorResponse `json:"-"`
+	Response      *PlanDetail    `json:"response,omitempty"`
+}
+
+type PlanDetail struct {
+	ID            string           `json:"id"`
+	ProductID     string           `json:"product_id"`
+	Name          string           `json:"name"`
+	Description   string           `json:"description"`
+	Status        string           `json:"status"`
+	BillingCycles []*BillingCycles `json:"billing_cycles"`
+	Taxes         *Taxes           `json:"taxes"`
+	CreateTime    string           `json:"create_time"`
+	UpdateTime    string           `json:"update_time"`
+	Links         []*Link          `json:"links,omitempty"`
+}
+
+type Taxes struct {
+	Percentage string `json:"percentage"`
+	Inclusive  bool   `json:"inclusive"`
+}
+
 type InvoiceNumber struct {
 	InvoiceNumber string `json:"invoice_number"`
 }

--- a/paypal/model.go
+++ b/paypal/model.go
@@ -929,6 +929,99 @@ type Taxes struct {
 	Inclusive  bool   `json:"inclusive"`
 }
 
+type CreateSubscriptionRsp struct {
+	Code          int                 `json:"-"`
+	Error         string              `json:"-"`
+	ErrorResponse *ErrorResponse      `json:"-"`
+	Response      *SubscriptionDetail `json:"response,omitempty"`
+}
+
+type SubscriptionDetail struct {
+	ID               string          `json:"id"`
+	Status           string          `json:"status"`
+	StatusUpdateTime string          `json:"status_update_time"`
+	PlanID           string          `json:"plan_id"`
+	PlanOverridden   bool            `json:"plan_overridden"`
+	StartTime        string          `json:"start_time"`
+	Quantity         string          `json:"quantity"`
+	ShippingAmount   *CommonAmount   `json:"shipping_amount"`
+	Subscriber       *Subscriber     `json:"subscriber"`
+	BillingInfo      *BillingInfoNew `json:"billing_info,omitempty"`
+	CreateTime       string          `json:"create_time"`
+	UpdateTime       string          `json:"update_time,omitempty"`
+	Links            []*Link         `json:"links,omitempty"`
+}
+
+type BillingInfoNew struct {
+	OutstandingBalance  *CommonAmount     `json:"outstanding_balance"`
+	CycleExecutions     []*CycleExecution `json:"cycle_executions"`
+	LastPayment         *LastPayment      `json:"last_payment"`
+	NextBillingTime     string            `json:"next_billing_time"`
+	FailedPaymentsCount int               `json:"failed_payments_count"`
+}
+
+type LastPayment struct {
+	Amount *CommonAmount `json:"amount"`
+	Time   string        `json:"time"`
+}
+
+type CycleExecution struct {
+	TenureType      string `json:"tenure_type"`
+	Sequence        int    `json:"sequence"`
+	CyclesCompleted int    `json:"cycles_completed"`
+	CyclesRemaining int    `json:"cycles_remaining"`
+	TotalCycles     int    `json:"total_cycles"`
+}
+
+type CommonAmount struct {
+	CurrencyCode string `json:"currency_code"`
+	Value        string `json:"value"`
+}
+
+type Subscriber struct {
+	Name            *Name            `json:"name"`
+	EmailAddress    string           `json:"email_address"`
+	PayerId         string           `json:"payer_id"`
+	ShippingAddress *ShippingAddress `json:"shipping_address"`
+}
+
+type ShippingAddress struct {
+	Name    *Name    `json:"name"`
+	Address *Address `json:"address"`
+}
+
+type SubscriptionDetailRsp struct {
+	Code          int                 `json:"-"`
+	Error         string              `json:"-"`
+	ErrorResponse *ErrorResponse      `json:"-"`
+	Response      *SubscriptionDetail `json:"response,omitempty"`
+}
+
+type ListTransSubscriptionRsp struct {
+	Code          int                `json:"-"`
+	Error         string             `json:"-"`
+	ErrorResponse *ErrorResponse     `json:"-"`
+	Response      *TransSubscription `json:"response,omitempty"`
+}
+type TransSubscription struct {
+	Transactions []*Transaction `json:"transactions"`
+	Links        []*Link        `json:"links,omitempty"`
+}
+type Transaction struct {
+	ID                  string               `json:"id"`
+	Status              string               `json:"status"`
+	PayerEmail          string               `json:"payer_email"`
+	PayerName           *Name                `json:"payer_name"`
+	AmountWithBreakdown *AmountWithBreakdown `json:"amount_with_breakdown"`
+	Time                string               `json:"time"`
+}
+
+type AmountWithBreakdown struct {
+	GrossAmount *CommonAmount `json:"gross_amount"`
+	FeeAmount   *CommonAmount `json:"fee_amount"`
+	NetAmount   *CommonAmount `json:"net_amount"`
+}
+
 type InvoiceNumber struct {
 	InvoiceNumber string `json:"invoice_number"`
 }

--- a/paypal/model.go
+++ b/paypal/model.go
@@ -1,6 +1,8 @@
 package paypal
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 type AccessToken struct {
 	Scope       string `json:"scope"`
@@ -1193,4 +1195,66 @@ type WebhookEvent struct {
 	Links           []*Link         `json:"links,omitempty"`
 	EventVersion    string          `json:"event_version"`
 	ResourceVersion string          `json:"resource_version"`
+}
+
+type CreateCatalogsProductsRep struct {
+	Code          int               `json:"-"`
+	Error         string            `json:"-"`
+	ErrorResponse *ErrorResponse    `json:"-"`
+	Response      *CatalogsProducts `json:"response,omitempty"`
+}
+
+type CatalogsProducts struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+	Category    string `json:"category"`
+	ImageURL    string `json:"image_url"`
+	HomeURL     string `json:"home_url"`
+	CreateTime  string `json:"create_time"`
+	UpdateTime  string `json:"update_time"`
+	Links       []struct {
+		Href   string `json:"href"`
+		Rel    string `json:"rel"`
+		Method string `json:"method"`
+	} `json:"links"`
+}
+
+type ProductsListRsp struct {
+	Code          int            `json:"-"`
+	Error         string         `json:"-"`
+	ErrorResponse *ErrorResponse `json:"-"`
+	Response      *ProductsList  `json:"response,omitempty"`
+}
+
+type ProductsList struct {
+	TotalItems int              `json:"total_items"`
+	TotalPages int              `json:"total_pages"`
+	Items      []*ProductDetail `json:"products"`
+	Links      []*Link          `json:"links,omitempty"`
+}
+
+type ProductsDetailRsp struct {
+	Code          int            `json:"-"`
+	Error         string         `json:"-"`
+	ErrorResponse *ErrorResponse `json:"-"`
+	Response      *ProductDetail `json:"response,omitempty"`
+}
+
+type ProductDetail struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Type        string `json:"type,omitempty"`
+	Category    string `json:"category,omitempty"`
+	ImageURL    string `json:"image_url,omitempty"`
+	HomeURL     string `json:"home_url,omitempty"`
+	CreateTime  string `json:"create_time"`
+	UpdateTime  string `json:"update_time,omitempty"`
+	Links       []struct {
+		Href   string `json:"href"`
+		Rel    string `json:"rel"`
+		Method string `json:"method"`
+	} `json:"links"`
 }

--- a/paypal/products.go
+++ b/paypal/products.go
@@ -1,0 +1,106 @@
+package paypal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/go-pay/gopay"
+	"net/http"
+)
+
+// 创建产品（CreateCatalogsProductsRep）
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/catalog-products/v1/#products_create
+func (c *Client) CreateCatalogsProduct(ctx context.Context, bm gopay.BodyMap) (ppRsp *CreateCatalogsProductsRep, err error) {
+	if err = bm.CheckEmptyError("name", "type"); err != nil {
+		return nil, err
+	}
+	res, bs, err := c.doPayPalPost(ctx, bm, productCreate)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &CreateCatalogsProductsRep{Code: Success}
+	ppRsp.Response = new(CatalogsProducts)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusCreated {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
+
+// 产品列表（ListCatalogsProducts）
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/catalog-products/v1/#products_list
+func (c *Client) ListCatalogsProducts(ctx context.Context, bm gopay.BodyMap) (ppRsp *ProductsListRsp, err error) {
+	uri := productList + "?" + bm.EncodeURLParams()
+	res, bs, err := c.doPayPalGet(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &ProductsListRsp{Code: Success}
+	ppRsp.Response = new(ProductsList)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusOK {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
+
+// 产品详情（CatalogsProductDetails）
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/catalog-products/v1/#products_get
+func (c *Client) CatalogsProductDetails(ctx context.Context, ProductID string, bm gopay.BodyMap) (ppRsp *ProductsDetailRsp, err error) {
+	if ProductID == gopay.NULL {
+		return nil, errors.New("product_id is empty")
+	}
+	uri := fmt.Sprintf(productDetail, ProductID) + "?" + bm.EncodeURLParams()
+	res, bs, err := c.doPayPalGet(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &ProductsDetailRsp{Code: Success}
+	ppRsp.Response = new(ProductDetail)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusOK {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
+
+// 更新产品（Update product）
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/catalog-products/v1/#products_patch
+func (c *Client) UpdateProduct(ctx context.Context, productID string, patchs []*Patch) (ppRsp *EmptyRsp, err error) {
+	if productID == gopay.NULL {
+		return nil, errors.New("product_id is empty")
+	}
+	url := fmt.Sprintf(productUpdate, productID)
+	res, bs, err := c.doPayPalPatch(ctx, patchs, url)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &EmptyRsp{Code: Success}
+	if res.StatusCode != http.StatusNoContent {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}

--- a/paypal/products_test.go
+++ b/paypal/products_test.go
@@ -1,0 +1,107 @@
+// Package paypal
+// Copyright 2025 Giga Inc. All Rights Reserved
+// Author: 刘静修 <jingxiu.liu@gigaai.cc>
+// Date: 2025/3/4
+/*
+   DESCRIPTION: xx
+   使用文档：xx
+*/
+package paypal
+
+import (
+	"github.com/go-pay/gopay"
+	"github.com/go-pay/xlog"
+	"testing"
+)
+
+func TestCreateProduct(t *testing.T) {
+
+	bm := make(gopay.BodyMap)
+	// can be AUTHORIZE
+	bm.Set("name", "Video Gen Service").
+		Set("description", "Video generate service").
+		Set("type", "DIGITAL").
+		Set("category", "PICTURE_VIDEO_PRODUCTION")
+	//Set("image_url", "https://example.com/streaming.jpg").
+	//Set("home_url", "https://example.com/home")
+	xlog.Debug("bm：", bm.JsonBody())
+
+	ppRsp, err := client.CreateCatalogsProduct(ctx, bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Response: %+v", ppRsp.Response)
+	for _, v := range ppRsp.Response.Links {
+		xlog.Debugf("ppRsp.Response.Links: %+v", v)
+	}
+}
+
+func TestListProduct(t *testing.T) {
+	ppRsp, err := client.ListCatalogsProducts(ctx, nil)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Response: %+v", ppRsp.Response)
+	for _, v := range ppRsp.Response.Items {
+		xlog.Debugf("ppRsp.Response.Item: %+v", v)
+	}
+	for _, v := range ppRsp.Response.Links {
+		xlog.Debugf("ppRsp.Response.Links: %+v", v)
+	}
+}
+
+func TestProductDetail(t *testing.T) {
+	ppRsp, err := client.CatalogsProductDetails(ctx, "PROD-10J947659N0823244", nil)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Response: %+v", ppRsp.Response)
+	for _, v := range ppRsp.Response.Links {
+		xlog.Debugf("ppRsp.Response.Links: %+v", v)
+	}
+}
+
+func TestUpdateProduct(t *testing.T) {
+	var ps []*Patch
+	item := &Patch{
+		Op:    "replace",
+		Path:  "/description", // reference_id is yourself set when create order
+		Value: "Video or model generate service",
+	}
+
+	ps = append(ps, item)
+
+	ppRsp, err := client.UpdateProduct(ctx, "PROD-10J947659N0823244", ps)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+}

--- a/paypal/subscriptions.go
+++ b/paypal/subscriptions.go
@@ -3,6 +3,7 @@ package paypal
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -26,6 +27,77 @@ func (c *Client) CreateBillingPlan(ctx context.Context, bm gopay.BodyMap) (ppRsp
 		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
 	}
 	if res.StatusCode != http.StatusCreated {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
+
+// 订阅列表（ListBillingPlan）
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#plans_list
+func (c *Client) ListBillingPlan(ctx context.Context, bm gopay.BodyMap) (ppRsp *BillingListRsp, err error) {
+	uri := subscriptionList + "?" + bm.EncodeURLParams()
+	res, bs, err := c.doPayPalGet(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &BillingListRsp{Code: Success}
+	ppRsp.Response = new(BillingPlans)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusOK {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
+
+// 订阅详情（CatalogsProductDetails）
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#plans_get
+func (c *Client) BillingPlanDetails(ctx context.Context, PlanID string, bm gopay.BodyMap) (ppRsp *PlanDetailRsp, err error) {
+	if PlanID == gopay.NULL {
+		return nil, errors.New("plan_id is empty")
+	}
+	uri := fmt.Sprintf(subscriptionDetail, PlanID) + "?" + bm.EncodeURLParams()
+	res, bs, err := c.doPayPalGet(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &PlanDetailRsp{Code: Success}
+	ppRsp.Response = new(PlanDetail)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusOK {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
+
+// 更新订阅（UpdateBillingPlan）
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#plans_patch
+func (c *Client) UpdateBillingPlan(ctx context.Context, PlanID string, patchs []*Patch) (ppRsp *EmptyRsp, err error) {
+	if PlanID == gopay.NULL {
+		return nil, errors.New("plan_id is empty")
+	}
+	url := fmt.Sprintf(subscriptionUpdate, PlanID)
+	res, bs, err := c.doPayPalPatch(ctx, patchs, url)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &EmptyRsp{Code: Success}
+	if res.StatusCode != http.StatusNoContent {
 		ppRsp.Code = res.StatusCode
 		ppRsp.Error = string(bs)
 		ppRsp.ErrorResponse = new(ErrorResponse)

--- a/paypal/subscriptions.go
+++ b/paypal/subscriptions.go
@@ -17,7 +17,7 @@ func (c *Client) CreateBillingPlan(ctx context.Context, bm gopay.BodyMap) (ppRsp
 	if err = bm.CheckEmptyError("product_id", "billing_cycles"); err != nil {
 		return nil, err
 	}
-	res, bs, err := c.doPayPalPost(ctx, bm, subscriptionCreate)
+	res, bs, err := c.doPayPalPost(ctx, bm, planCreate)
 	if err != nil {
 		return nil, err
 	}
@@ -35,11 +35,11 @@ func (c *Client) CreateBillingPlan(ctx context.Context, bm gopay.BodyMap) (ppRsp
 	return ppRsp, nil
 }
 
-// 订阅列表（ListBillingPlan）
+// 订阅计划列表（ListBillingPlan）
 // Code = 0 is success
 // 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#plans_list
 func (c *Client) ListBillingPlan(ctx context.Context, bm gopay.BodyMap) (ppRsp *BillingListRsp, err error) {
-	uri := subscriptionList + "?" + bm.EncodeURLParams()
+	uri := planList + "?" + bm.EncodeURLParams()
 	res, bs, err := c.doPayPalGet(ctx, uri)
 	if err != nil {
 		return nil, err
@@ -58,14 +58,14 @@ func (c *Client) ListBillingPlan(ctx context.Context, bm gopay.BodyMap) (ppRsp *
 	return ppRsp, nil
 }
 
-// 订阅详情（CatalogsProductDetails）
+// 订阅计划详情（CatalogsProductDetails）
 // Code = 0 is success
 // 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#plans_get
 func (c *Client) BillingPlanDetails(ctx context.Context, PlanID string, bm gopay.BodyMap) (ppRsp *PlanDetailRsp, err error) {
 	if PlanID == gopay.NULL {
 		return nil, errors.New("plan_id is empty")
 	}
-	uri := fmt.Sprintf(subscriptionDetail, PlanID) + "?" + bm.EncodeURLParams()
+	uri := fmt.Sprintf(planDetail, PlanID) + "?" + bm.EncodeURLParams()
 	res, bs, err := c.doPayPalGet(ctx, uri)
 	if err != nil {
 		return nil, err
@@ -84,20 +84,163 @@ func (c *Client) BillingPlanDetails(ctx context.Context, PlanID string, bm gopay
 	return ppRsp, nil
 }
 
-// 更新订阅（UpdateBillingPlan）
+// 更新订阅计划（UpdateBillingPlan）
 // Code = 0 is success
 // 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#plans_patch
 func (c *Client) UpdateBillingPlan(ctx context.Context, PlanID string, patchs []*Patch) (ppRsp *EmptyRsp, err error) {
 	if PlanID == gopay.NULL {
 		return nil, errors.New("plan_id is empty")
 	}
-	url := fmt.Sprintf(subscriptionUpdate, PlanID)
+	url := fmt.Sprintf(planUpdate, PlanID)
 	res, bs, err := c.doPayPalPatch(ctx, patchs, url)
 	if err != nil {
 		return nil, err
 	}
 	ppRsp = &EmptyRsp{Code: Success}
 	if res.StatusCode != http.StatusNoContent {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
+
+// 创建订阅（CreateBillingSubscription）
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_create
+func (c *Client) CreateBillingSubscription(ctx context.Context, bm gopay.BodyMap) (ppRsp *CreateSubscriptionRsp, err error) {
+	if err = bm.CheckEmptyError("plan_id"); err != nil {
+		return nil, err
+	}
+	res, bs, err := c.doPayPalPost(ctx, bm, subscriptionCreate)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &CreateSubscriptionRsp{Code: Success}
+	ppRsp.Response = new(SubscriptionDetail)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusCreated {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
+
+// 订阅详情（SubscriptionDetails）
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_get
+func (c *Client) SubscriptionDetails(ctx context.Context, SubscriptionID string, bm gopay.BodyMap) (ppRsp *SubscriptionDetailRsp, err error) {
+	if SubscriptionID == gopay.NULL {
+		return nil, errors.New("subscription_id is empty")
+	}
+	uri := fmt.Sprintf(subscriptionDetail, SubscriptionID) + "?" + bm.EncodeURLParams()
+	res, bs, err := c.doPayPalGet(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &SubscriptionDetailRsp{Code: Success}
+	ppRsp.Response = new(SubscriptionDetail)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusOK {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
+
+// 暂停订阅（SuspendSubscription）
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_suspend
+func (c *Client) SuspendSubscription(ctx context.Context, SubscriptionID string, bm gopay.BodyMap) (ppRsp *EmptyRsp, err error) {
+	if err = bm.CheckEmptyError("reason"); err != nil {
+		return nil, err
+	}
+	uri := fmt.Sprintf(subscriptionSuspend, SubscriptionID)
+	res, bs, err := c.doPayPalPost(ctx, bm, uri)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &EmptyRsp{Code: Success}
+
+	if res.StatusCode != http.StatusNoContent {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
+
+// 取消订阅（CancelSubscription）
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_cancel
+func (c *Client) CancelSubscription(ctx context.Context, SubscriptionID string, bm gopay.BodyMap) (ppRsp *EmptyRsp, err error) {
+	if err = bm.CheckEmptyError("reason"); err != nil {
+		return nil, err
+	}
+	uri := fmt.Sprintf(subscriptionCancel, SubscriptionID)
+	res, bs, err := c.doPayPalPost(ctx, bm, uri)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &EmptyRsp{Code: Success}
+
+	if res.StatusCode != http.StatusNoContent {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
+
+// 激活订阅（ActivateSubscription）
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_activate
+func (c *Client) ActivateSubscription(ctx context.Context, SubscriptionID string, bm gopay.BodyMap) (ppRsp *EmptyRsp, err error) {
+	if err = bm.CheckEmptyError("reason"); err != nil {
+		return nil, err
+	}
+	uri := fmt.Sprintf(subscriptionActivate, SubscriptionID)
+	res, bs, err := c.doPayPalPost(ctx, bm, uri)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &EmptyRsp{Code: Success}
+
+	if res.StatusCode != http.StatusNoContent {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
+
+// List transactions for subscription（ListTransSubscription）
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_transactions
+func (c *Client) ListTransSubscription(ctx context.Context, SubscriptionID string, bm gopay.BodyMap) (ppRsp *ListTransSubscriptionRsp, err error) {
+	uri := fmt.Sprintf(subscriptionTransactions, SubscriptionID) + "?" + bm.EncodeURLParams()
+	res, bs, err := c.doPayPalGet(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &ListTransSubscriptionRsp{Code: Success}
+	ppRsp.Response = new(TransSubscription)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusOK {
 		ppRsp.Code = res.StatusCode
 		ppRsp.Error = string(bs)
 		ppRsp.ErrorResponse = new(ErrorResponse)

--- a/paypal/subscriptions_test.go
+++ b/paypal/subscriptions_test.go
@@ -28,7 +28,7 @@ func TestClient_CreateBillingPlan(t *testing.T) {
 
 	// 创建 PayPal 支付订单
 	bm := make(gopay.BodyMap)
-	bm.Set("product_id", "PROD-9TH539347F0791830").
+	bm.Set("product_id", "PROD-10J947659N0823244").
 		Set("name", "gopay").
 		Set("billing_cycles", billingCycles).
 		Set("description", "Monthly subscription for premium users").
@@ -55,4 +55,67 @@ func TestClient_CreateBillingPlan(t *testing.T) {
 	for _, v := range ppRsp.Response.Links {
 		xlog.Debugf("ppRsp.Response.Links: %+v", v)
 	}
+}
+
+func TestListBillingPlan(t *testing.T) {
+	ppRsp, err := client.ListBillingPlan(ctx, nil)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Response: %+v", ppRsp.Response)
+	for _, v := range ppRsp.Response.Plans {
+		xlog.Debugf("ppRsp.Response.Item: %+v", v)
+	}
+	for _, v := range ppRsp.Response.Links {
+		xlog.Debugf("ppRsp.Response.Links: %+v", v)
+	}
+}
+
+func TestBillingPlanDetail(t *testing.T) {
+	ppRsp, err := client.BillingPlanDetails(ctx, "P-4A621926UG9673307M7D3JIA", nil)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Response: %+v", ppRsp.Response)
+	for _, v := range ppRsp.Response.Links {
+		xlog.Debugf("ppRsp.Response.Links: %+v", v)
+	}
+}
+
+func TestUpdateBillingPlan(t *testing.T) {
+	var ps []*Patch
+	item := &Patch{
+		Op:    "replace",
+		Path:  "/name", // reference_id is yourself set when create order
+		Value: "Updated Video Streaming Service Plan",
+	}
+
+	ps = append(ps, item)
+
+	ppRsp, err := client.UpdateBillingPlan(ctx, "P-4A621926UG9673307M7D3JIA", ps)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
 }

--- a/paypal/subscriptions_test.go
+++ b/paypal/subscriptions_test.go
@@ -119,3 +119,122 @@ func TestUpdateBillingPlan(t *testing.T) {
 	}
 	xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
 }
+
+func TestCreateBillingSubscription(t *testing.T) {
+
+	// 创建 PayPal 支付订单
+	bm := make(gopay.BodyMap)
+	bm.Set("plan_id", "P-4A621926UG9673307M7D3JIA")
+	xlog.Debug("bm：", bm.JsonBody())
+
+	ppRsp, err := client.CreateBillingSubscription(ctx, bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Response: %+v", ppRsp.Response)
+	for _, v := range ppRsp.Response.Links {
+		xlog.Debugf("ppRsp.Response.Links: %+v", v)
+	}
+}
+
+func TestSubscriptionDetails(t *testing.T) {
+	ppRsp, err := client.SubscriptionDetails(ctx, "I-5V3YPKHJ9LE4", nil)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Response: %+v", ppRsp.Response)
+	for _, v := range ppRsp.Response.Links {
+		xlog.Debugf("ppRsp.Response.Links: %+v", v)
+	}
+}
+
+func TestSuspendSubscription(t *testing.T) {
+
+	bm := make(gopay.BodyMap)
+	bm.Set("reason", "wait a minute")
+	ppRsp, err := client.SuspendSubscription(ctx, "I-5V3YPKHJ9LE4", bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+}
+
+func TestCancelSubscription(t *testing.T) {
+	bm := make(gopay.BodyMap)
+	bm.Set("reason", "cancel a minute")
+
+	ppRsp, err := client.CancelSubscription(ctx, "I-5V3YPKHJ9LE4", bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+}
+
+func TestActivateSubscription(t *testing.T) {
+	bm := make(gopay.BodyMap)
+	bm.Set("reason", "activate")
+	ppRsp, err := client.ActivateSubscription(ctx, "I-5V3YPKHJ9LE4", bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+}
+
+func TestListTransSubscription(t *testing.T) {
+	bm := make(gopay.BodyMap)
+	bm.Set("start_time", "2025-03-03T07:50:20.940Z")
+	bm.Set("end_time", "2025-04-21T07:50:20.940Z")
+	ppRsp, err := client.ListTransSubscription(ctx, "I-5V3YPKHJ9LE4", bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if ppRsp.Code != Success {
+		xlog.Debugf("ppRsp.Code: %+v", ppRsp.Code)
+		xlog.Debugf("ppRsp.Error: %+v", ppRsp.Error)
+		xlog.Debugf("ppRsp.ErrorResponse: %+v", ppRsp.ErrorResponse)
+		return
+	}
+	xlog.Debugf("ppRsp.Response: %+v", ppRsp.Response)
+	for _, v := range ppRsp.Response.Transactions {
+		xlog.Debugf("ppRsp.Response.Item: %+v", v)
+	}
+	for _, v := range ppRsp.Response.Links {
+		xlog.Debugf("ppRsp.Response.Links: %+v", v)
+	}
+}


### PR DESCRIPTION
增加paypal接口 并增加测试用例 
 产品功能接口 创建、更新、详情、列表接口
订阅计划接口 订阅计划列表、订阅计划详情、更新订阅计划  
订阅接口 订阅生成链接 、 取消订阅、暂停订阅、激活订阅、 订阅事务列表
