### PR TITLE
修复 Apple 内购消费上报接口：从 v1 切换到 v2

### DIFF
--- a/apple/constant.go
+++ b/apple/constant.go
@@ -17,7 +17,7 @@ const (
 	getAllSubscriptionStatuses = "/inApps/v1/subscriptions/%s" // transactionId
 
 	// Send Consumption Information
-	sendConsumptionInformation = "/inApps/v1/transactions/consumption/%s" // transactionId
+	sendConsumptionInformation = "/inApps/v2/transactions/consumption/%s" // transactionId
 
 	// Look Up Order ID
 	lookUpOrderID = "/inApps/v1/lookup/%s" // orderId


### PR DESCRIPTION
## 背景

`gopay` 当前对 **Apple App Store 内购（In-App Purchase）** 的支持中，
在进行消费信息上报（Send Consumption Information）时，使用的是 v1 接口：

- `https://api.storekit.itunes.apple.com/inApps/v1/transactions/consumption/{originalTransactionId}`

在实际接入过程中，针对合法的 `originalTransactionId` 和请求体，
该 v1 接口会稳定返回 HTTP 400，且无法正常获取有效的错误信息，
导致 Apple 内购这条支付链路无法完整跑通。

同时，Apple 官方最新的 App Store Server API 文档中，推荐使用 v2 版本的
Send Consumption Information 接口。

---

## 修改内容

本 PR 仅对 **Apple 支付（Apple App Store 内购）** 相关代码做了如下调整：

- 将消费信息上报接口地址由 v1 切换为 v2：
  - 由  
    `sendConsumptionInformation = "/inApps/v1/transactions/consumption/%s" // transactionId`
  - 调整为  
    `sendConsumptionInformation = "/inApps/v2/transactions/consumption/%s" // transactionId`

- 保持原有请求体结构和业务逻辑不变，仅修改接口路径。

---

## 影响范围

- 仅影响 `gopay` 中的 **Apple App Store 内购支付** 通道。
- 不涉及微信支付、支付宝等其他支付方式的代码，其他渠道行为不受影响。
- 对调用方来说，使用方式保持不变，无需额外配置。

---

## 兼容性与风险

- v2 接口是 Apple 官方推荐的 Send Consumption Information 版本，
  在相同请求参数下可以正常返回预期结果，修复了原先 v1 接口 400 的问题。
- 改动只涉及一个接口路径，未调整结构体定义或公共方法签名，
  理论上对现有使用方是无感升级。

如维护者更倾向于同时兼容 v1/v2，也可以在此基础上改为通过配置或参数指定版本。

---

## 测试情况

- 在 Apple Sandbox 环境下，对真实的 `originalTransactionId` 进行验证：
  - 使用 v1 接口时，请求稳定返回 HTTP 400；
  - 切换到 v2 接口后，在相同请求体下能够正常返回成功响应，消费上报流程可正常完成。

如有需要，我可以根据项目规范补充相应的单元测试或示例代码。
