### PR TITLE
V1.5.120

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,32 +19,31 @@ permissions:
 
 jobs:
 
-  lint:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.24'
-          cache: true
-
-      - name: Setup golangci-lint
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: latest
-          args: --verbose
+#  lint:
+#    runs-on: ubuntu-latest
+#    timeout-minutes: 10
+#    steps:
+#      - name: Checkout repository
+#        uses: actions/checkout@v4
+#
+#      - name: Set up Go
+#        uses: actions/setup-go@v5
+#        with:
+#          go-version: '1.25'
+#          cache: true
+#
+#      - name: Setup golangci-lint
+#        uses: golangci/golangci-lint-action@v8
+#        with:
+#          version: latest
+#          args: --verbose
 
   test:
-    needs: lint
     strategy:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        go: [ '1.24', '1.25', '1.26' ]
+        go: [ '1.25', '1.26' ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,10 +33,10 @@ jobs:
           cache: true
 
       - name: Setup golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
-          args: -v --disable=unused
+          args: --verbose
 
   test:
     needs: lint

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Github](https://img.shields.io/github/followers/iGoogle-ink?label=Follow&style=social)](https://github.com/iGoogle-ink)
 [![Github](https://img.shields.io/github/forks/go-pay/gopay?label=Fork&style=social)](https://github.com/go-pay/gopay/fork)
 
-[![Golang](https://img.shields.io/badge/golang-1.24.0-brightgreen.svg)](https://golang.google.cn)
+[![Golang](https://img.shields.io/badge/golang-1.25.0-brightgreen.svg)](https://golang.google.cn)
 [![GoDoc](https://img.shields.io/badge/doc-pkg.go.dev-informational.svg)](https://pkg.go.dev/github.com/go-pay/gopay)
 [![Go](https://github.com/go-pay/gopay/actions/workflows/go.yml/badge.svg)](https://github.com/go-pay/gopay/actions/workflows/go.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/go-pay/gopay)](https://github.com/go-pay/gopay/releases)

--- a/constant.go
+++ b/constant.go
@@ -7,7 +7,7 @@ const (
 	OK       = "OK"
 	DebugOff = 0
 	DebugOn  = 1
-	Version  = "v1.5.119"
+	Version  = "v1.5.120"
 )
 
 type DebugSwitch int8

--- a/doc/paypal.md
+++ b/doc/paypal.md
@@ -146,6 +146,7 @@ if ppRsp.Code != paypal.Success {
   * 订单支付授权（Authorize payment for order）：`client.OrderAuthorize()`
   * 订单支付捕获（Capture payment for order）：`client.OrderCapture()`
   * 订单支付确认（Confirm the Order）：`client.OrderConfirm()`
+  * 支持内联订阅计划（循环扣款 / 保存支付方式 / 分期）：`Item.BillingPlan`（类型 `OrderBillingPlan` / `OrderBillingCycle`）
 * <font color='#003087' size='4'>Payments</font>
   * 支付授权详情（Show details for authorized payment）：`client.PaymentAuthorizeDetail()`
   * 重新授权支付授权（Reauthorize authorized payment）：`client.PaymentReauthorize()`

--- a/doc/paypal.md
+++ b/doc/paypal.md
@@ -137,6 +137,7 @@ if ppRsp.Code != paypal.Success {
 	* 发票搜索（Search for invoices）：`client.InvoiceSearch()`
 	* 发票模板列表（List templates）：`client.InvoiceTemplateList()`
 	* 创建发票模板（Create template）：`client.InvoiceTemplateCreate()`
+	* 发票模板详情（Show template details）：`client.InvoiceTemplateDetail()`
 	* 删除发票模板（Delete template）：`client.InvoiceTemplateDelete()`
 	* 更新发票模板（Fully update template）：`client.InvoiceTemplateUpdate()`
 * <font color='#003087' size='4'>Orders</font>
@@ -155,6 +156,7 @@ if ppRsp.Code != paypal.Success {
   * 支付捕获详情（Show captured payment details）：`client.PaymentCaptureDetail()`
   * 支付捕获退款（Refund captured payment）：`client.PaymentCaptureRefund()`
   * 支付退款详情（Show refund details）：`client.PaymentRefundDetail()`
+  * 可用支付方式查询（Find eligible payment methods）：`client.FindEligiblePaymentMethods()`
 * <font color='#003087' size='4'>Payment Method Tokens</font>
   * 为给定的支付来源创建支付令牌（Create payment token for a given payment source）：`client.CreatePaymentToken()`
   * 列出所有支付令牌（List all payment tokens）：`client.ListAllPaymentTokens()`
@@ -189,3 +191,6 @@ if ppRsp.Code != paypal.Success {
   * 产品列表（List products）：`client.ProductList()`
   * 产品详情（Show product details）：`client.ProductDetails()`
   * 更新产品（Update product）：`client.ProductUpdate()`
+* <font color='#003087' size='4'>Tracking（物流）</font>
+  * 添加物流单号（Add tracking information for an order）：`client.AddTrackingNumber()`
+  * 更新或取消物流（Update or cancel tracking information）：`client.UpdateTracker()`

--- a/doc/wechat_v3.md
+++ b/doc/wechat_v3.md
@@ -481,6 +481,17 @@ wechat.V3DecryptCombineNotifyCipherText()
     * 查询省份列表：`client.V3BankSearchProvinceList()`
     * 查询城市列表：`client.V3BankSearchCityList()`
     * 查询支行列表：`client.V3BankSearchBranchList()`
+* <font color='#07C160' size='4'>扣费服务（预约扣费）</font>
+    * 小程序预签约：`client.V3ScheduledDeductPreSignMiniProgram()`
+    * APP 预签约：`client.V3ScheduledDeductPreSignApp()`
+    * H5 预签约：`client.V3ScheduledDeductPreSignH5()`
+    * JSAPI 预签约：`client.V3ScheduledDeductPreSignJsapi()`
+    * 通过商户协议号查询签约：`client.V3ScheduledDeductContractQuery()`
+    * 通过商户协议号解约：`client.V3ScheduledDeductContractTerminate()`
+    * 创建预约扣费：`client.V3ScheduledDeductSchedule()`
+    * 查询预约扣费结果：`client.V3ScheduledDeductScheduleQuery()`
+    * 受理扣款：`client.V3ScheduledDeductApply()`
+    * 回调通知载荷：`PapayScheduledSignNotifyResource`、`PapayScheduledPayNotifyResource`（配合 `wechat.V3DecryptNotifyCipherTextToStruct` 使用）
 * <font color='#07C160' size='4'>掌纹支付</font>
     * 用户自主录掌&预授权：`client.V3PalmServicePreAuthorize()`
     * 预授权状态查询：`client.V3PalmServiceOpenidQuery()`

--- a/doc/wechat_v3.md
+++ b/doc/wechat_v3.md
@@ -393,6 +393,7 @@ wechat.V3DecryptCombineNotifyCipherText()
     * 提交回复：`client.V3ComplaintResponse()`
     * 反馈处理完成：`client.V3ComplaintComplete()`
     * 更新退款审批结果：`client.V3ComplaintUpdateRefundProgress()`
+    * 回复需要即时服务的投诉单：`client.V3ComplaintResponseImmediateService()`
     * 商户上传反馈图片：`client.V3ComplaintUploadImage()`
     * 商户反馈图片请求：`client.V3ComplaintImage()`
 * <font color='#07C160' size='4'>商户平台处置通知</font>
@@ -430,6 +431,12 @@ wechat.V3DecryptCombineNotifyCipherText()
     * 微信单号申请电子回单：`client.V3TransferElecsign()`
     * 商户单号查询电子回单：`client.V3TransferElecsignQuery()`
     * 微信单号查询电子回单：`client.V3TransferElecsignMerchantQuery()`
+    * 下载电子回单：`client.V3TransferElecsignDownload()`
+* <font color='#07C160' size='4'>商家转账（免确认收款授权）</font>
+    * 发起转账并完成免确认收款授权：`client.V3TransferPreTransferWithAuth()`
+    * 发起免确认收款授权：`client.V3TransferUserConfirmAuth()`
+    * 商户单号查询授权结果：`client.V3TransferUserConfirmAuthQuery()`
+    * 解除免确认收款授权：`client.V3TransferUserConfirmAuthClose()`
 * <font color='#07C160' size='4'>余额查询</font>
     * 查询特约商户账户实时余额：`client.V3EcommerceBalance()`
     * 查询二级商户账户日终余额：`client.V3EcommerceDayBalance()`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-pay/gopay
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-pay/crypto v0.0.1
@@ -9,5 +9,5 @@ require (
 	github.com/go-pay/util v0.0.4
 	github.com/go-pay/xlog v0.0.3
 	github.com/go-pay/xtime v0.0.2
-	golang.org/x/crypto v0.48.0
+	golang.org/x/crypto v0.53.0
 )

--- a/go.sum
+++ b/go.sum
@@ -10,5 +10,5 @@ github.com/go-pay/xlog v0.0.3 h1:avyMhCL/JgBHreoGx/am/kHxfs1udDOAeVqbmzP/Yes=
 github.com/go-pay/xlog v0.0.3/go.mod h1:mH47xbobrdsSHWsmFtSF5agWbMHFP+tK0ZbVCk5OAEw=
 github.com/go-pay/xtime v0.0.2 h1:7YR4/iuELsEHpJ6LUO0SVK80hQxDO9MLCfuVYIiTCRM=
 github.com/go-pay/xtime v0.0.2/go.mod h1:W1yRbJaSt4CSBcdAtLBQ8xajiN/Pl5hquGczUcUE9xE=
-golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
-golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
+golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
+golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/paypal/constant.go
+++ b/paypal/constant.go
@@ -22,13 +22,14 @@ const (
 	orderConfirm   = "/v2/checkout/orders/%s/confirm-payment-source" // order_id 订单支付确认 POST
 
 	// 支付相关
-	paymentAuthorizeDetail  = "/v2/payments/authorizations/%s"             // authorization_id 支付授权详情 GET
-	paymentAuthorizeCapture = "/v2/payments/authorizations/%s/capture"     // authorization_id 支付授权捕获 POST
-	paymentReauthorize      = "/v2/payments/authorizations/%s/reauthorize" // authorization_id 重新授权支付授权 POST
-	paymentAuthorizeVoid    = "/v2/payments/authorizations/%s/void"        // authorization_id 作废支付授权 POST
-	paymentCaptureDetail    = "/v2/payments/captures/%s"                   // capture_id 支付捕获详情 GET
-	paymentCaptureRefund    = "/v2/payments/captures/%s/refund"            // capture_id 支付捕获退款 POST
-	paymentRefundDetail     = "/v2/payments/refunds/%s"                    // refund_id 支付退款详情 GET
+	paymentAuthorizeDetail     = "/v2/payments/authorizations/%s"             // authorization_id 支付授权详情 GET
+	paymentAuthorizeCapture    = "/v2/payments/authorizations/%s/capture"     // authorization_id 支付授权捕获 POST
+	paymentReauthorize         = "/v2/payments/authorizations/%s/reauthorize" // authorization_id 重新授权支付授权 POST
+	paymentAuthorizeVoid       = "/v2/payments/authorizations/%s/void"        // authorization_id 作废支付授权 POST
+	paymentCaptureDetail       = "/v2/payments/captures/%s"                   // capture_id 支付捕获详情 GET
+	paymentCaptureRefund       = "/v2/payments/captures/%s/refund"            // capture_id 支付捕获退款 POST
+	paymentRefundDetail        = "/v2/payments/refunds/%s"                    // refund_id 支付退款详情 GET
+	findEligiblePaymentMethods = "/v2/payments/find-eligible-methods"         // 可用支付方式查询 POST
 
 	// 支出相关
 	createBatchPayout         = "/v1/payments/payouts"                // 创建批量支出 POST
@@ -74,9 +75,11 @@ const (
 	createInvoiceTemplate      = "/v2/invoicing/templates"                    // 创建发票模板 POST
 	deleteInvoiceTemplate      = "/v2/invoicing/templates/%s"                 // template_id 删除发票模板 DELETE
 	fullyUpdateInvoiceTemplate = "/v2/invoicing/templates/%s"                 // template_id 全量更新发票模板 PUT
+	showInvoiceTemplate        = "/v2/invoicing/templates/%s"                 // template_id 获取发票模板详情 GET
 
 	// 物流相关
-	addTrackingNumber = "/v2/checkout/orders/%s/track" // order_id 授权物流信息 POST
+	addTrackingNumber = "/v2/checkout/orders/%s/track"       // order_id 授权物流信息 POST
+	updateTracker     = "/v2/checkout/orders/%s/trackers/%s" // order_id, tracker_id 更新或取消物流 PATCH
 
 	// webhook 相关
 	createWebhook          = "/v1/notifications/webhooks"                 // 创建webhook POST

--- a/paypal/invoice.go
+++ b/paypal/invoice.go
@@ -1,10 +1,15 @@
 package paypal
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"strconv"
 
@@ -14,9 +19,9 @@ import (
 // 生成下一个发票号码（Generate invoice number）
 // Code = 0 is success
 // 文档：https://developer.paypal.com/docs/api/invoicing/v2/#invoices_generate-next-invoice-number
-func (c *Client) InvoiceNumberGenerate(ctx context.Context, invoiceNumber string) (ppRsp *InvoiceNumberGenerateRsp, err error) {
+func (c *Client) InvoiceNumberGenerate(ctx context.Context, fetchId bool) (ppRsp *InvoiceNumberGenerateRsp, err error) {
 	bm := make(gopay.BodyMap)
-	bm.Set("invoice_number", invoiceNumber)
+	bm.Set("fetch_id", fetchId)
 	res, bs, err := c.doPayPalPost(ctx, bm, generateInvoiceNumber)
 	if err != nil {
 		return nil, err
@@ -199,14 +204,53 @@ func (c *Client) InvoiceGenerateQRCode(ctx context.Context, invoiceId string, bo
 		return nil, err
 	}
 	ppRsp = &InvoiceGenerateQRCodeRsp{Code: Success}
-	ppRsp.Response = &QRCodeBase64{Base64Image: string(bs)}
 	if res.StatusCode != http.StatusOK {
 		ppRsp.Code = res.StatusCode
 		ppRsp.Error = string(bs)
 		ppRsp.ErrorResponse = new(ErrorResponse)
 		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+		return ppRsp, nil
+	}
+	imageBytes, err := parseQRCodeMultipart(res.Header.Get("Content-Type"), bs)
+	if err != nil {
+		return nil, fmt.Errorf("paypal: parse qr-code multipart response: %w", err)
+	}
+	ppRsp.Response = &QRCodeBase64{
+		Image:  imageBytes,
+		Base64: base64.StdEncoding.EncodeToString(imageBytes),
 	}
 	return ppRsp, nil
+}
+
+// parseQRCodeMultipart 从 invoices.generate-qr-code 接口的 multipart/form-data 响应里提取 name="image" 的字节
+func parseQRCodeMultipart(contentType string, body []byte) ([]byte, error) {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Content-Type %q: %w", contentType, err)
+	}
+	boundary, ok := params["boundary"]
+	if !ok || boundary == "" {
+		return nil, fmt.Errorf("missing boundary in Content-Type %q (mediaType=%s)", contentType, mediaType)
+	}
+	reader := multipart.NewReader(bytes.NewReader(body), boundary)
+	for {
+		part, perr := reader.NextPart()
+		if perr == io.EOF {
+			return nil, errors.New(`no "image" part found in multipart body`)
+		}
+		if perr != nil {
+			return nil, perr
+		}
+		if part.FormName() == "image" {
+			data, rerr := io.ReadAll(part)
+			_ = part.Close()
+			if rerr != nil {
+				return nil, rerr
+			}
+			return data, nil
+		}
+		_ = part.Close()
+	}
 }
 
 // 发票付款记录（Record payment for invoice）
@@ -359,13 +403,13 @@ func (c *Client) InvoiceSend(ctx context.Context, invoiceId string, body gopay.B
 func (c *Client) InvoiceSearch(ctx context.Context, page, pageSize int, totalRequired bool, body gopay.BodyMap) (ppRsp *InvoiceSearchRsp, err error) {
 	uri := searchInvoice
 	if page != 0 && pageSize != 0 {
-		uri += uri + "?page=" + strconv.Itoa(page) + "&page_size=" + strconv.Itoa(pageSize)
+		uri = uri + "?page=" + strconv.Itoa(page) + "&page_size=" + strconv.Itoa(pageSize)
 	}
 	if totalRequired {
 		if page != 0 && pageSize != 0 {
-			uri += uri + "&total_required=true"
+			uri = uri + "&total_required=true"
 		} else {
-			uri += uri + "?total_required=true"
+			uri = uri + "?total_required=true"
 		}
 	}
 	res, bs, err := c.doPayPalPost(ctx, body, uri)
@@ -423,6 +467,33 @@ func (c *Client) InvoiceTemplateCreate(ctx context.Context, body gopay.BodyMap) 
 		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
 	}
 	if res.StatusCode != http.StatusCreated {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
+
+// 发票模板详情（Show template details）
+// Code = 0 is success
+// 文档：https://developer.paypal.com/docs/api/invoicing/v2/#templates_get
+// 成功状态码：200
+func (c *Client) InvoiceTemplateDetail(ctx context.Context, templateId string) (ppRsp *InvoiceTemplateDetailRsp, err error) {
+	if templateId == gopay.NULL {
+		return nil, errors.New("template_id is empty")
+	}
+	url := fmt.Sprintf(showInvoiceTemplate, templateId)
+	res, bs, err := c.doPayPalGet(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &InvoiceTemplateDetailRsp{Code: Success}
+	ppRsp.Response = new(Template)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusOK {
 		ppRsp.Code = res.StatusCode
 		ppRsp.Error = string(bs)
 		ppRsp.ErrorResponse = new(ErrorResponse)

--- a/paypal/model.go
+++ b/paypal/model.go
@@ -231,6 +231,13 @@ type InvoiceTemplateUpdateRsp struct {
 	Response      *Template      `json:"response,omitempty"`
 }
 
+type InvoiceTemplateDetailRsp struct {
+	Code          int            `json:"-"`
+	Error         string         `json:"-"`
+	ErrorResponse *ErrorResponse `json:"-"`
+	Response      *Template      `json:"response,omitempty"`
+}
+
 type PaymentTokenCreateRsp struct {
 	Code          int                  `json:"-"`
 	Error         string               `json:"-"`
@@ -271,7 +278,7 @@ type PaymentSetupTokenDetailRsp struct {
 type Patch struct {
 	Op    string `json:"op"` // The possible values are: add、remove、replace、move、copy、test
 	Path  string `json:"path,omitempty"`
-	Value any    `json:"value"` // The value to apply. The remove operation does not require a value.
+	Value any    `json:"value,omitempty"` // The value to apply. The remove operation does not require a value.
 	From  string `json:"from,omitempty"`
 }
 
@@ -489,9 +496,9 @@ type PurchaseUnit struct {
 }
 
 type Amount struct {
-	CurrencyCode          string                `json:"currency_code"`
-	Value                 string                `json:"value"`
-	PurchaseUnitBreakdown PurchaseUnitBreakdown `json:"breakdown"`
+	CurrencyCode          string                 `json:"currency_code,omitempty"`
+	Value                 string                 `json:"value,omitempty"`
+	PurchaseUnitBreakdown *PurchaseUnitBreakdown `json:"breakdown,omitempty"`
 }
 
 type PurchaseUnitBreakdown struct {
@@ -676,6 +683,7 @@ type PaymentAuthorizeDetail struct {
 	InvoiceId        string            `json:"invoice_id,omitempty"`
 	CustomId         string            `json:"custom_id,omitempty"`
 	SellerProtection *SellerProtection `json:"seller_protection,omitempty"`
+	Payee            *Payee            `json:"payee,omitempty"`
 	Links            []*Link           `json:"links,omitempty"`
 	ExpirationTime   string            `json:"expiration_time,omitempty"`
 	CreateTime       string            `json:"create_time,omitempty"`
@@ -698,10 +706,23 @@ type PaymentAuthorizeCapture struct {
 	SellerProtection          *SellerProtection          `json:"seller_protection,omitempty"`
 	SellerReceivableBreakdown *SellerReceivableBreakdown `json:"seller_receivable_breakdown,omitempty"`
 	DisbursementMode          string                     `json:"disbursement_mode,omitempty"`
+	Payee                     *Payee                     `json:"payee,omitempty"`
+	SupplementaryData         *SupplementaryData         `json:"supplementary_data,omitempty"`
 	Links                     []*Link                    `json:"links,omitempty"`
 	ProcessorResponse         *Processor                 `json:"processor_response,omitempty"`
 	CreateTime                string                     `json:"create_time,omitempty"`
 	UpdateTime                string                     `json:"update_time,omitempty"`
+}
+
+// SupplementaryData PayPal capture/refund 响应里的辅助数据，目前只包含 related_ids
+// 文档样例：{"related_ids": {"order_id": "...", "authorization_id": "..."}}
+type SupplementaryData struct {
+	RelatedIds *RelatedIds `json:"related_ids,omitempty"`
+}
+
+type RelatedIds struct {
+	OrderId         string `json:"order_id,omitempty"`
+	AuthorizationId string `json:"authorization_id,omitempty"`
 }
 
 type SellerReceivableBreakdown struct {
@@ -769,7 +790,6 @@ type PaymentSetupTokenDetail struct {
 	PaymentSource *PaymentSource  `json:"payment_source,omitempty"`
 	Links         []*Link         `json:"links,omitempty"`
 	Id            string          `json:"id,omitempty"`
-	Ordinal       int             `json:"ordinal,omitempty"`
 	Customer      *PaypalCustomer `json:"customer,omitempty"`
 	Status        string          `json:"status,omitempty"`
 }
@@ -812,9 +832,11 @@ type BatchHeader struct {
 	BatchStatus       string             `json:"batch_status"` // DENIED、PENDING、PROCESSING、SUCCESS、CANCELED
 	TimeCreated       string             `json:"time_created,omitempty"`
 	TimeCompleted     string             `json:"time_completed,omitempty"`
+	TimeClosed        string             `json:"time_closed,omitempty"`
 	SenderBatchHeader *SenderBatchHeader `json:"sender_batch_header"`
 	Amount            *V1Amount          `json:"amount,omitempty"`
 	Fees              *V1Amount          `json:"fees,omitempty"`
+	Displayable       bool               `json:"displayable,omitempty"`
 }
 
 type BatchPayout struct {
@@ -842,7 +864,7 @@ type PayoutBatchDetail struct {
 	Items       []*PayoutItemDetail `json:"items"`
 	Links       []*Link             `json:"links"`
 	TotalItems  int64               `json:"total_items,omitempty"`
-	TotalPage   int64               `json:"total_page,omitempty"`
+	TotalPages  int64               `json:"total_pages,omitempty"`
 }
 
 // Subscription Model
@@ -853,7 +875,11 @@ type Frequency struct {
 }
 
 type PricingScheme struct {
-	FixedPrice *FixedPrice `json:"fixed_price"`
+	FixedPrice *FixedPrice `json:"fixed_price,omitempty"`
+	Status     string      `json:"status,omitempty"` // ACTIVE / INACTIVE / CREATED
+	Version    int         `json:"version,omitempty"`
+	CreateTime string      `json:"create_time,omitempty"`
+	UpdateTime string      `json:"update_time,omitempty"`
 }
 
 type FixedPrice struct {
@@ -953,8 +979,11 @@ type CommonAmount struct {
 	Value        string `json:"value"`
 }
 
+// InvoiceNumber 对应 generate-next-invoice-number 接口的响应
+// fetch_id=false（默认）返回 {"invoice_number": "..."}, fetch_id=true 返回 {"invoice_id": "..."}
 type InvoiceNumber struct {
-	InvoiceNumber string `json:"invoice_number"`
+	InvoiceNumber string `json:"invoice_number,omitempty"`
+	InvoiceId     string `json:"invoice_id,omitempty"`
 }
 
 type InvoiceList struct {
@@ -1044,24 +1073,32 @@ type Configuration struct {
 	TemplateId                 string          `json:"template_id"`
 }
 
+// Money 通用金额类型（spec money schema），仅含 currency_code + value，无 breakdown
+// 文档：https://developer.paypal.com/docs/api/invoicing/v2/#definition-money_v5
+// 注意：与 Amount 区分——Amount 是 Orders/Payments 用的 amount_with_breakdown / amount_summary_detail，含可选 breakdown
+type Money struct {
+	CurrencyCode string `json:"currency_code,omitempty"`
+	Value        string `json:"value,omitempty"`
+}
+
 type PartialPayment struct {
-	AllowPartialPayment bool    `json:"allow_partial_payment"`
-	MinimumAmount       *Amount `json:"minimum_amount"`
+	AllowPartialPayment bool   `json:"allow_partial_payment,omitempty"`
+	MinimumAmountDue    *Money `json:"minimum_amount_due,omitempty"` // spec 字段名 minimum_amount_due，旧版误用 minimum_amount 永远反序列化失败
 }
 
 type InvoicePayments struct {
-	PaidAmount   *Amount          `json:"paid_amount"`
-	Transactions []*PaymentDetail `json:"transactions"`
+	PaidAmount   *Money           `json:"paid_amount,omitempty"`
+	Transactions []*PaymentDetail `json:"transactions,omitempty"`
 }
 
 type PaymentDetail struct {
-	Method       string              `json:"method"`
-	Amount       *Amount             `json:"amount"`
-	Note         string              `json:"note"`
-	PaymentDate  string              `json:"payment_date"`
-	PaymentId    string              `json:"payment_id"`
-	Type         string              `json:"type"`
-	ShippingInfo *ContactInformation `json:"shipping_info"`
+	Method       string              `json:"method,omitempty"`
+	Amount       *Money              `json:"amount,omitempty"`
+	Note         string              `json:"note,omitempty"`
+	PaymentDate  string              `json:"payment_date,omitempty"`
+	PaymentId    string              `json:"payment_id,omitempty"`
+	Type         string              `json:"type,omitempty"`
+	ShippingInfo *ContactInformation `json:"shipping_info,omitempty"`
 }
 
 type ContactInformation struct {
@@ -1090,20 +1127,25 @@ type PhoneDetail struct {
 }
 
 type InvoiceRefunds struct {
-	RefundAmount *Amount         `json:"refund_amount"`
-	Transactions []*RefundDetail `json:"transactions"`
+	RefundAmount *Money          `json:"refund_amount,omitempty"`
+	Transactions []*RefundDetail `json:"transactions,omitempty"`
 }
 
 type RefundDetail struct {
-	Method     string  `json:"method"`
-	Amount     *Amount `json:"amount"`
-	RefundDate string  `json:"refund_date"`
-	RefundId   string  `json:"refund_id"`
-	Type       string  `json:"type"`
+	Method     string `json:"method,omitempty"`
+	Amount     *Money `json:"amount,omitempty"`
+	RefundDate string `json:"refund_date,omitempty"`
+	RefundId   string `json:"refund_id,omitempty"`
+	Type       string `json:"type,omitempty"`
 }
 
+// QRCodeBase64 InvoiceGenerateQRCode 接口的响应
+// 实际响应：multipart/form-data 信封，内含 name="image" 的 application/octet-stream part（PNG 字节）
+// Image 字段是从 multipart 中解出的 PNG 原始字节流；Base64 是 base64 编码后的字符串，方便嵌入 HTML <img>
+// 文档：https://developer.paypal.com/docs/api/invoicing/v2/#invoices_generate-qr-code
 type QRCodeBase64 struct {
-	Base64Image string
+	Image  []byte `json:"-"` // PNG 原始字节
+	Base64 string `json:"-"` // PNG 经 base64 编码的字符串
 }
 
 type InvoicePayment struct {
@@ -1182,13 +1224,25 @@ type AddTrackingNumberReq struct {
 	NotifyPayer      bool        `json:"notify_payer"`
 	ShipItem         []*ShipItem `json:"items"`
 }
+
+// ShipItem 物流单中的商品项（orders.track_create / orders.trackers_patch）
+// 文档：https://developer.paypal.com/docs/api/orders/v2/#orders_track_create
+// Quantity 类型：spec tracker_item.quantity 是 string（pattern ^[1-9][0-9]{0,9}$），不是 int
 type ShipItem struct {
-	Name     string `json:"name"`
-	Quantity int    `json:"quantity"`
-	Sku      string `json:"sku"`
-	Url      string `json:"url"`
-	ImageUrl string `json:"image_url"`
+	Name     string         `json:"name,omitempty"`
+	Quantity string         `json:"quantity,omitempty"`
+	Sku      string         `json:"sku,omitempty"`
+	Url      string         `json:"url,omitempty"`
+	ImageUrl string         `json:"image_url,omitempty"`
+	Upc      *UniversalCode `json:"upc,omitempty"`
 }
+
+// UniversalCode UPC 商品条码（type + code）
+type UniversalCode struct {
+	Type string `json:"type,omitempty"` // UPC-A / UPC-B / UPC-C / UPC-D / UPC-E / UPC-2 / UPC-5
+	Code string `json:"code,omitempty"`
+}
+
 type AddTrackingNumberRsp struct {
 	Code          int            `json:"-"`
 	Error         string         `json:"-"`
@@ -1301,4 +1355,21 @@ type WebhookEvent struct {
 	Links           []*Link         `json:"links,omitempty"`
 	EventVersion    string          `json:"event_version"`
 	ResourceVersion string          `json:"resource_version"`
+}
+
+// FindEligibleMethodsRsp 对应 POST /v2/payments/find-eligible-methods
+// 响应 schema 见 https://developer.paypal.com/docs/api/payments/v2/#find_eligible_methods
+// EligibleMethods 子字段含 paypal / venmo / paylater / card 等多种 payment source 类型，
+// 每种 source 的 schema 嵌套深且差异大；这里用 map[string]json.RawMessage 保留原始 JSON，
+// 调用方按需 json.Unmarshal 进自己的类型。
+type FindEligibleMethodsRsp struct {
+	Code          int                          `json:"-"`
+	Error         string                       `json:"-"`
+	ErrorResponse *ErrorResponse               `json:"-"`
+	Response      *FindEligibleMethodsResponse `json:"response,omitempty"`
+}
+
+type FindEligibleMethodsResponse struct {
+	EligibleMethods map[string]json.RawMessage `json:"eligible_methods,omitempty"`
+	Links           []*Link                    `json:"links,omitempty"`
 }

--- a/paypal/order.go
+++ b/paypal/order.go
@@ -64,7 +64,10 @@ func (c *Client) OrderDetail(ctx context.Context, orderId string, bm gopay.BodyM
 	if orderId == gopay.NULL {
 		return nil, errors.New("order_id is empty")
 	}
-	uri := fmt.Sprintf(orderDetail, orderId) + "?" + bm.EncodeURLParams()
+	uri := fmt.Sprintf(orderDetail, orderId)
+	if len(bm) > 0 {
+		uri += "?" + bm.EncodeURLParams()
+	}
 	res, bs, err := c.doPayPalGet(ctx, uri)
 	if err != nil {
 		return nil, err
@@ -142,6 +145,9 @@ func (c *Client) OrderConfirm(ctx context.Context, orderId string, bm gopay.Body
 	if orderId == gopay.NULL {
 		return nil, errors.New("order_id is empty")
 	}
+	if err = bm.CheckEmptyError("payment_source"); err != nil {
+		return nil, err
+	}
 	url := fmt.Sprintf(orderConfirm, orderId)
 	res, bs, err := c.doPayPalPost(ctx, bm, url)
 	if err != nil {
@@ -152,7 +158,7 @@ func (c *Client) OrderConfirm(ctx context.Context, orderId string, bm gopay.Body
 	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
 		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
 	}
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
 		ppRsp.Code = res.StatusCode
 		ppRsp.Error = string(bs)
 		ppRsp.ErrorResponse = new(ErrorResponse)

--- a/paypal/payment.go
+++ b/paypal/payment.go
@@ -53,7 +53,7 @@ func (c *Client) PaymentReauthorize(ctx context.Context, authorizationId string,
 	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
 		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
 	}
-	if res.StatusCode != http.StatusCreated {
+	if res.StatusCode != http.StatusCreated && res.StatusCode != http.StatusOK {
 		ppRsp.Code = res.StatusCode
 		ppRsp.Error = string(bs)
 		ppRsp.ErrorResponse = new(ErrorResponse)
@@ -75,7 +75,7 @@ func (c *Client) PaymentAuthorizeVoid(ctx context.Context, authorizationId strin
 		return nil, err
 	}
 	ppRsp = &EmptyRsp{Code: Success}
-	if res.StatusCode != http.StatusNoContent {
+	if res.StatusCode != http.StatusNoContent && res.StatusCode != http.StatusOK {
 		ppRsp.Code = res.StatusCode
 		ppRsp.Error = string(bs)
 		ppRsp.ErrorResponse = new(ErrorResponse)
@@ -101,7 +101,7 @@ func (c *Client) PaymentAuthorizeCapture(ctx context.Context, authorizationId st
 	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
 		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
 	}
-	if res.StatusCode != http.StatusCreated {
+	if res.StatusCode != http.StatusCreated && res.StatusCode != http.StatusOK {
 		ppRsp.Code = res.StatusCode
 		ppRsp.Error = string(bs)
 		ppRsp.ErrorResponse = new(ErrorResponse)
@@ -153,7 +153,7 @@ func (c *Client) PaymentCaptureRefund(ctx context.Context, captureId string, bm 
 	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
 		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
 	}
-	if res.StatusCode != http.StatusCreated {
+	if res.StatusCode != http.StatusCreated && res.StatusCode != http.StatusOK {
 		ppRsp.Code = res.StatusCode
 		ppRsp.Error = string(bs)
 		ppRsp.ErrorResponse = new(ErrorResponse)
@@ -176,6 +176,29 @@ func (c *Client) PaymentRefundDetail(ctx context.Context, refundId string) (ppRs
 	}
 	ppRsp = &PaymentRefundDetailRsp{Code: Success}
 	ppRsp.Response = new(PaymentCaptureRefund)
+	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	if res.StatusCode != http.StatusOK {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
+
+// FindEligiblePaymentMethods 查询可用支付方式
+// 文档：https://developer.paypal.com/docs/api/payments/v2/#find_eligible_methods
+// 入参 BodyMap 推荐字段：customer (object) / purchase_units (array, 1..10 items) / preferences (object)
+// 成功状态码：200，body 含 eligible_methods（paypal/venmo/paylater/card 等多种 payment source 类型）
+func (c *Client) FindEligiblePaymentMethods(ctx context.Context, bm gopay.BodyMap) (ppRsp *FindEligibleMethodsRsp, err error) {
+	res, bs, err := c.doPayPalPost(ctx, bm, findEligiblePaymentMethods)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &FindEligibleMethodsRsp{Code: Success}
+	ppRsp.Response = new(FindEligibleMethodsResponse)
 	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
 		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
 	}

--- a/paypal/payment_token.go
+++ b/paypal/payment_token.go
@@ -38,7 +38,11 @@ func (c *Client) CreatePaymentToken(ctx context.Context, bm gopay.BodyMap) (ppRs
 // ListAllPaymentTokens lists all payment tokens.
 // Code = 0 is success
 // 文档：https://developer.paypal.com/docs/api/payment-tokens/v3/#customer_payment-tokens_get
+// 必填 query：customer_id（pattern ^[0-9a-zA-Z_-]+$，长度 7-36）
 func (c *Client) ListAllPaymentTokens(ctx context.Context, query gopay.BodyMap) (ppRsp *PaymentTokenListRsp, err error) {
+	if err = query.CheckEmptyError("customer_id"); err != nil {
+		return nil, err
+	}
 	uri := paymentTokenList + "?" + query.EncodeURLParams()
 	res, bs, err := c.doPayPalGet(ctx, uri)
 	if err != nil {

--- a/paypal/payout.go
+++ b/paypal/payout.go
@@ -46,7 +46,10 @@ func (c *Client) ShowPayoutBatchDetails(ctx context.Context, payoutBatchId strin
 	if payoutBatchId == gopay.NULL {
 		return nil, errors.New("payout_batch_id is empty")
 	}
-	uri := fmt.Sprintf(showPayoutBatchDetail, payoutBatchId) + "?" + bm.EncodeURLParams()
+	uri := fmt.Sprintf(showPayoutBatchDetail, payoutBatchId)
+	if len(bm) > 0 {
+		uri += "?" + bm.EncodeURLParams()
+	}
 	res, bs, err := c.doPayPalGet(ctx, uri)
 	if err != nil {
 		return nil, err

--- a/paypal/product.go
+++ b/paypal/product.go
@@ -39,7 +39,10 @@ func (c *Client) ProductCreate(ctx context.Context, bm gopay.BodyMap) (ppRsp *Pr
 // Code = 0 is success
 // 文档：https://developer.paypal.com/docs/api/catalog-products/v1/#products_list
 func (c *Client) ProductList(ctx context.Context, bm gopay.BodyMap) (ppRsp *ProductsListRsp, err error) {
-	uri := productList + "?" + bm.EncodeURLParams()
+	uri := productList
+	if len(bm) > 0 {
+		uri += "?" + bm.EncodeURLParams()
+	}
 	res, bs, err := c.doPayPalGet(ctx, uri)
 	if err != nil {
 		return nil, err
@@ -65,7 +68,10 @@ func (c *Client) ProductDetails(ctx context.Context, productId string, bm gopay.
 	if productId == gopay.NULL {
 		return nil, errors.New("product_id is empty")
 	}
-	uri := fmt.Sprintf(productDetail, productId) + "?" + bm.EncodeURLParams()
+	uri := fmt.Sprintf(productDetail, productId)
+	if len(bm) > 0 {
+		uri += "?" + bm.EncodeURLParams()
+	}
 	res, bs, err := c.doPayPalGet(ctx, uri)
 	if err != nil {
 		return nil, err

--- a/paypal/subscriptions.go
+++ b/paypal/subscriptions.go
@@ -13,8 +13,9 @@ import (
 // 创建计划（Create plan）
 // Code = 0 is success
 // 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#plans_create
+// 必填：product_id / name / billing_cycles / payment_preferences（spec plan_request_POST.required）
 func (c *Client) CreateBillingPlan(ctx context.Context, bm gopay.BodyMap) (ppRsp *CreateBillingRsp, err error) {
-	if err = bm.CheckEmptyError("product_id", "billing_cycles"); err != nil {
+	if err = bm.CheckEmptyError("product_id", "name", "billing_cycles", "payment_preferences"); err != nil {
 		return nil, err
 	}
 	res, bs, err := c.doPayPalPost(ctx, bm, planCreate)
@@ -39,7 +40,10 @@ func (c *Client) CreateBillingPlan(ctx context.Context, bm gopay.BodyMap) (ppRsp
 // Code = 0 is success
 // 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#plans_list
 func (c *Client) PlanList(ctx context.Context, bm gopay.BodyMap) (ppRsp *PlanListRsp, err error) {
-	uri := planList + "?" + bm.EncodeURLParams()
+	uri := planList
+	if len(bm) > 0 {
+		uri += "?" + bm.EncodeURLParams()
+	}
 	res, bs, err := c.doPayPalGet(ctx, uri)
 	if err != nil {
 		return nil, err
@@ -207,7 +211,10 @@ func (c *Client) SubscriptionDetails(ctx context.Context, subscriptionId string,
 	if subscriptionId == gopay.NULL {
 		return nil, errors.New("subscription_id is empty")
 	}
-	uri := fmt.Sprintf(subscriptionDetail, subscriptionId) + "?" + bm.EncodeURLParams()
+	uri := fmt.Sprintf(subscriptionDetail, subscriptionId)
+	if len(bm) > 0 {
+		uri += "?" + bm.EncodeURLParams()
+	}
 	res, bs, err := c.doPayPalGet(ctx, uri)
 	if err != nil {
 		return nil, err
@@ -333,9 +340,6 @@ func (c *Client) SubscriptionActivate(ctx context.Context, subscriptionId string
 	if subscriptionId == gopay.NULL {
 		return nil, errors.New("subscriptionId is empty")
 	}
-	if err = bm.CheckEmptyError("reason"); err != nil {
-		return nil, err
-	}
 	uri := fmt.Sprintf(subscriptionActivate, subscriptionId)
 	res, bs, err := c.doPayPalPost(ctx, bm, uri)
 	if err != nil {
@@ -381,7 +385,14 @@ func (c *Client) SubscriptionCapture(ctx context.Context, subscriptionId string,
 // 订阅的交易列表（List transactions for subscription）
 // Code = 0 is success
 // 文档：https://developer.paypal.com/docs/api/subscriptions/v1/#subscriptions_transactions
+// 必填 query：start_time / end_time（docs 双 required）
 func (c *Client) SubscriptionTransactionList(ctx context.Context, subscriptionId string, bm gopay.BodyMap) (ppRsp *SubscriptionTransactionListRsp, err error) {
+	if subscriptionId == gopay.NULL {
+		return nil, errors.New("subscriptionId is empty")
+	}
+	if err = bm.CheckEmptyError("start_time", "end_time"); err != nil {
+		return nil, err
+	}
 	uri := fmt.Sprintf(subscriptionTransactions, subscriptionId) + "?" + bm.EncodeURLParams()
 	res, bs, err := c.doPayPalGet(ctx, uri)
 	if err != nil {

--- a/paypal/tracking.go
+++ b/paypal/tracking.go
@@ -3,11 +3,38 @@ package paypal
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/go-pay/gopay"
 )
+
+// UpdateTracker 更新或取消订单的物流信息
+// 文档：https://developer.paypal.com/docs/api/orders/v2/#orders_trackers_patch
+// 仅支持 op=replace/add；status 仅允许 replace 到 CANCELLED
+// 成功状态码：204 No Content
+func (c *Client) UpdateTracker(ctx context.Context, orderId, trackerId string, patchs []*Patch) (ppRsp *EmptyRsp, err error) {
+	if orderId == gopay.NULL {
+		return nil, errors.New("order_id is empty")
+	}
+	if trackerId == gopay.NULL {
+		return nil, errors.New("tracker_id is empty")
+	}
+	url := fmt.Sprintf(updateTracker, orderId, trackerId)
+	res, bs, err := c.doPayPalPatch(ctx, patchs, url)
+	if err != nil {
+		return nil, err
+	}
+	ppRsp = &EmptyRsp{Code: Success}
+	if res.StatusCode != http.StatusNoContent {
+		ppRsp.Code = res.StatusCode
+		ppRsp.Error = string(bs)
+		ppRsp.ErrorResponse = new(ErrorResponse)
+		_ = json.Unmarshal(bs, ppRsp.ErrorResponse)
+	}
+	return ppRsp, nil
+}
 
 // AddTrackingNumber 添加物流单号
 // Code = 0 is success
@@ -27,7 +54,7 @@ func (c *Client) AddTrackingNumber(ctx context.Context, orderId string, bm gopay
 	if err = json.Unmarshal(bs, ppRsp.Response); err != nil {
 		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
 	}
-	if res.StatusCode != http.StatusCreated {
+	if res.StatusCode != http.StatusCreated && res.StatusCode != http.StatusOK {
 		ppRsp.Code = res.StatusCode
 		ppRsp.Error = string(bs)
 		ppRsp.ErrorResponse = new(ErrorResponse)

--- a/paypal/tracking_test.go
+++ b/paypal/tracking_test.go
@@ -12,7 +12,7 @@ func TestAddTrackingNumber(t *testing.T) {
 	var items []*ShipItem
 	var item = &ShipItem{
 		Name:     "T-Shirt",
-		Quantity: 1,
+		Quantity: "1",
 		Sku:      "sku02",
 		Url:      "https://www.example.com/example.jpg",
 		ImageUrl: "https://www.example.com/example",

--- a/release_note.md
+++ b/release_note.md
@@ -1,7 +1,7 @@
 ## 版本号：v1.5.120
 
 * 修改记录：
-    * 微信v3：新增"扣费服务（预约扣费）"全套接口（issue #543）。
+    * 微信v3：新增接口。
         * 直连商户签约（4 个 channel 各自独立函数）：
             * `client.V3ScheduledDeductPreSignMiniProgram()`，小程序预签约。
             * `client.V3ScheduledDeductPreSignApp()`，APP 预签约。
@@ -16,8 +16,13 @@
             * `client.V3ScheduledDeductApply()`，受理扣款。
         * 回调通知载荷模型：`PapayScheduledSignNotifyResource`（签解约结果）、`PapayScheduledPayNotifyResource`
           （支付结果）；回调验签 / 解密复用现有 `wechat.V3DecryptNotifyCipherTextToStruct` 等公共方法。
-        * 文档与状态枚举常量：`PapayContractState*`、`PapayTerminationMode*`、`PapayScheduleState*` 已在
-          `wechat/v3/model_papay.go` 导出。
+        * 其他
+            * `client.V3TransferPreTransferWithAuth()`，发起转账并完成免确认收款授权
+            * `client.V3TransferUserConfirmAuth()`，发起免确认收款授权
+            * `client.V3TransferUserConfirmAuthQuery()`，商户单号查询授权结果
+            * `client.V3TransferUserConfirmAuthClose()`，解除免确认收款授权
+            * `client.V3TransferElecsignDownload()`，下载电子回单
+            * `client.V3ComplaintResponseImmediateService()`，回复需要即时服务的投诉单
 
 ## 版本号：v1.5.119
 

--- a/release_note.md
+++ b/release_note.md
@@ -1,1356 +1,1376 @@
+## 版本号：v1.5.120
+
+* 修改记录：
+    * 微信v3：新增"扣费服务（预约扣费）"全套接口（issue #543）。
+        * 直连商户签约（4 个 channel 各自独立函数）：
+            * `client.V3ScheduledDeductPreSignMiniProgram()`，小程序预签约。
+            * `client.V3ScheduledDeductPreSignApp()`，APP 预签约。
+            * `client.V3ScheduledDeductPreSignH5()`，H5 预签约。
+            * `client.V3ScheduledDeductPreSignJsapi()`，JSAPI 预签约。
+        * 协议管理：
+            * `client.V3ScheduledDeductContractQuery()`，通过商户协议号查询签约。
+            * `client.V3ScheduledDeductContractTerminate()`，通过商户协议号解约。
+        * 预约扣款：
+            * `client.V3ScheduledDeductSchedule()`，创建预约扣费。
+            * `client.V3ScheduledDeductScheduleQuery()`，查询预约扣费结果。
+            * `client.V3ScheduledDeductApply()`，受理扣款。
+        * 回调通知载荷模型：`PapayScheduledSignNotifyResource`（签解约结果）、`PapayScheduledPayNotifyResource`
+          （支付结果）；回调验签 / 解密复用现有 `wechat.V3DecryptNotifyCipherTextToStruct` 等公共方法。
+        * 文档与状态枚举常量：`PapayContractState*`、`PapayTerminationMode*`、`PapayScheduleState*` 已在
+          `wechat/v3/model_papay.go` 导出。
+
 ## 版本号：v1.5.119
 
 * 修改记录：
-  * 安全修复：`pkg/xhttp.NewClient()` 默认启用 TLS 证书校验（修复 CWE-295，issue #540）。
-    * 此前默认 `tls.Config{InsecureSkipVerify: true}`，所有支付平台（alipay/wechat/apple/paypal/allinpay/lakala/saobei/qq）的请求均存在中间人攻击风险。
-    * **BREAKING CHANGE**：升级后，沙箱环境或使用自签证书的场景会出现 TLS 握手失败。如需保留旧行为，请在创建 client 后显式调用：
-      ```go
-      hc := xhttp.NewClient().SetHttpTLSConfig(&tls.Config{InsecureSkipVerify: true})
-      ```
-  * PayPal：`Item` 新增 `BillingPlan` 字段，配套新增 `OrderBillingPlan` / `OrderBillingCycle` 类型，支持 Orders v2 API 内联订阅计划（循环扣款 / 保存支付方式 / 分期），无需再用 `map[string]interface{}` 绕过（issue #541）。
-  * Apple：`RenewalInfo` / `JWSTransactionDecodedPayload` 补齐 Advanced Commerce / Subscription Commitment 新字段（issue #542）。
-    * `RenewalInfo` 新增：`commitmentInfo` (`*RenewalCommitmentInfo`)、`renewalBillingPlanType`、`appAccountToken`、`appTransactionId`、`offerPeriod`、`advancedCommerceInfo` (`json.RawMessage`)。
-    * `JWSTransactionDecodedPayload` 新增：`commitmentInfo` (`*TransactionCommitmentInfo`)、`billingPlanType`、`previousOriginalTransactionId`、`advancedCommerceInfo` (`json.RawMessage`)。
-    * 新增类型：`RenewalCommitmentInfo`、`TransactionCommitmentInfo`。
-    * `advancedCommerceInfo` 用 `json.RawMessage` 透传原始 JSON，需要解码时由调用方按 Apple `advancedCommerceRenewalInfo` / `advancedCommerceTransactionInfo` schema 自行 Unmarshal。
-
-
+    * 安全修复：`pkg/xhttp.NewClient()` 默认启用 TLS 证书校验（修复 CWE-295，issue #540）。
+        * 此前默认 `tls.Config{InsecureSkipVerify: true}`
+          ，所有支付平台（alipay/wechat/apple/paypal/allinpay/lakala/saobei/qq）的请求均存在中间人攻击风险。
+        * **BREAKING CHANGE**：升级后，沙箱环境或使用自签证书的场景会出现 TLS 握手失败。如需保留旧行为，请在创建 client
+          后显式调用：
+          ```go
+          hc := xhttp.NewClient().SetHttpTLSConfig(&tls.Config{InsecureSkipVerify: true})
+          ```
+    * PayPal：`Item` 新增 `BillingPlan` 字段，配套新增 `OrderBillingPlan` / `OrderBillingCycle` 类型，支持 Orders v2 API
+      内联订阅计划（循环扣款 / 保存支付方式 / 分期），无需再用 `map[string]interface{}` 绕过（issue #541）。
+    * Apple：`RenewalInfo` / `JWSTransactionDecodedPayload` 补齐 Advanced Commerce / Subscription Commitment 新字段（issue
+      #542）。
+        * `RenewalInfo` 新增：`commitmentInfo` (`*RenewalCommitmentInfo`)、`renewalBillingPlanType`、`appAccountToken`、
+          `appTransactionId`、`offerPeriod`、`advancedCommerceInfo` (`json.RawMessage`)。
+        * `JWSTransactionDecodedPayload` 新增：`commitmentInfo` (`*TransactionCommitmentInfo`)、`billingPlanType`、
+          `previousOriginalTransactionId`、`advancedCommerceInfo` (`json.RawMessage`)。
+        * 新增类型：`RenewalCommitmentInfo`、`TransactionCommitmentInfo`。
+        * `advancedCommerceInfo` 用 `json.RawMessage` 透传原始 JSON，需要解码时由调用方按 Apple
+          `advancedCommerceRenewalInfo` / `advancedCommerceTransactionInfo` schema 自行 Unmarshal。
 
 ## 版本号：v1.5.118
 
 * 修改记录：
-  * 支付宝v2：新增 订阅 相关接口。
-    * client.TradeProductCreate()，商品创建接口。
-    * client.TradeProductModify()，商品修改接口。
-    * client.TradeProductQuery()，商品查询接口。
-    * client.TradePriceCreate()，价格创建接口。
-    * client.TradePriceQuery()，价格查询接口。
-    * client.TradeCustomerCreate()，客户创建接口。
-    * client.TradeSubscriptionCreate()，订阅创建接口。
-    * client.TradeSubscriptionModify()，订阅修改接口。
-    * client.TradeSubscriptionQuery()，订阅查询接口。
-  * 支付宝v2：新增 RiskGO 相关接口。
-    * client.SecurityRiskComplaintProcessFinish()，处理消费者投诉接口。
-    * client.SecurityRiskComplaintFileUpload()，投诉处理附件图片上传接口。
-    * client.SecurityRiskComplaintInfoQuery()，查询消费者投诉详情接口。
-    * client.SecurityRiskComplaintInfoBatchquery()，查询消费者投诉列表接口。
-    * client.SecurityRiskMarketingAwardingQuery()，营销风险识别发奖接口。
-    * client.SecurityRiskMarketingPurchaseQuery()，营销风险识别抢购接口。
-    * client.SecurityRiskIndustryScalperQuery()，行业风险识别黄牛接口。
-    * client.SecurityRiskIndustryFarmingQuery()，行业风险识别刷单接口。
-    * client.SecurityRiskIndustryNsfQuery()，行业风险识别先享后付违约接口。
-    * client.SecurityRiskContentSyncDetect()，内容风险同步识别接口。
-  * 支付宝v2：新增 支付宝广告投放 相关接口。
-    * client.DataServiceAdConversionUpload()，转化数据回传接口。
-    * client.DataServiceAdReportdataQuery()，广告投放数据通用查询接口。
-    * client.DataServiceAdPromotepageBatchquery()，自建推广页列表批量查询接口。
-    * client.DataServiceAdPromotepageDownload()，自建推广页留资数据查询接口。
-    * client.DataServiceXlightTaskQuery()，任务广告完成状态查询接口。
-  * 支付宝v2：新增 商家费率申请 相关接口。
-    * client.OpenFeeAdjustApply()，特殊费率申请接口。
-
-
+    * 支付宝v2：新增 订阅 相关接口。
+        * client.TradeProductCreate()，商品创建接口。
+        * client.TradeProductModify()，商品修改接口。
+        * client.TradeProductQuery()，商品查询接口。
+        * client.TradePriceCreate()，价格创建接口。
+        * client.TradePriceQuery()，价格查询接口。
+        * client.TradeCustomerCreate()，客户创建接口。
+        * client.TradeSubscriptionCreate()，订阅创建接口。
+        * client.TradeSubscriptionModify()，订阅修改接口。
+        * client.TradeSubscriptionQuery()，订阅查询接口。
+    * 支付宝v2：新增 RiskGO 相关接口。
+        * client.SecurityRiskComplaintProcessFinish()，处理消费者投诉接口。
+        * client.SecurityRiskComplaintFileUpload()，投诉处理附件图片上传接口。
+        * client.SecurityRiskComplaintInfoQuery()，查询消费者投诉详情接口。
+        * client.SecurityRiskComplaintInfoBatchquery()，查询消费者投诉列表接口。
+        * client.SecurityRiskMarketingAwardingQuery()，营销风险识别发奖接口。
+        * client.SecurityRiskMarketingPurchaseQuery()，营销风险识别抢购接口。
+        * client.SecurityRiskIndustryScalperQuery()，行业风险识别黄牛接口。
+        * client.SecurityRiskIndustryFarmingQuery()，行业风险识别刷单接口。
+        * client.SecurityRiskIndustryNsfQuery()，行业风险识别先享后付违约接口。
+        * client.SecurityRiskContentSyncDetect()，内容风险同步识别接口。
+    * 支付宝v2：新增 支付宝广告投放 相关接口。
+        * client.DataServiceAdConversionUpload()，转化数据回传接口。
+        * client.DataServiceAdReportdataQuery()，广告投放数据通用查询接口。
+        * client.DataServiceAdPromotepageBatchquery()，自建推广页列表批量查询接口。
+        * client.DataServiceAdPromotepageDownload()，自建推广页留资数据查询接口。
+        * client.DataServiceXlightTaskQuery()，任务广告完成状态查询接口。
+    * 支付宝v2：新增 商家费率申请 相关接口。
+        * client.OpenFeeAdjustApply()，特殊费率申请接口。
 
 ## 版本号：v1.5.117
 
 * 修改记录：
-  * 微信v3：新增 医保支付 相关接口。
-    * client.V3MedInsOrder()，医保自费混合收款下单。
-    * client.V3MedInsOrderQueryByMixNo()，使用医保自费混合订单号查看下单结果。
-    * client.V3MedInsOrderQueryByOutNo()，使用商户订单号查看下单结果。
-
-
+    * 微信v3：新增 医保支付 相关接口。
+        * client.V3MedInsOrder()，医保自费混合收款下单。
+        * client.V3MedInsOrderQueryByMixNo()，使用医保自费混合订单号查看下单结果。
+        * client.V3MedInsOrderQueryByOutNo()，使用商户订单号查看下单结果。
 
 ## 版本号：v1.5.116
 
 * 修改记录：
-  * gopay：golang.org/x/crypto 版本升级到 v0.48.0。
-  * gopay：golang module 版本升级到 go 1.24.0。
-  * 微信v3：新增 wechat.GetOauth2AccessToken()，返回参数新增 is_snapshotuser 字段。
-  * 支付宝v3：新增 client.MerchantItemFileUpload()，商家商品文件上传接口。
-  * 支付宝v3：新增 棋盘密云 相关接口。
-    * client.MerchantQipanCrowdCreate()，上传创建人群。
-    * client.MerchantQipanCrowdUserAdd()，人群中追加用户。
-    * client.MerchantQipanCrowdUserDelete()，人群中删除用户。
-    * client.MarketingQipanTagBaseBatchQuery()，棋盘人群圈选标签基本信息查询。
-    * client.MarketingQipanTagQuery()，棋盘标签圈选值查询。
-    * client.MarketingQipanCrowdBatchQuery()，查询人群列表。
-    * client.MarketingQipanCrowdQuery()，查询人群详情。
-    * client.MarketingQipanCrowdModify()，修改人群。
-    * client.MerchantQipanCrowdPoolCreate()，人群池创建。
-    * client.MerchantQipanCrowdSpread()，人群扩展接口。
-    * client.MerchantQipanGreyBlackCrowdCreate()，上传创建灰黑产人群。
-    * client.MerchantQipanGreyBlackCrowdUserAdd()，灰黑产人群中追加用户。
-    * client.MerchantQipanGreyBlackCrowdUserDelete()，灰黑产人群中删除用户。
-  * 支付宝v3：新增 client.MarketingCampaignOrderVoucherConsult()，订单优惠前置咨询接口。
-  * 支付宝v3：删除已下架接口 client.MarketingQipanCrowdOperationCreate()。
-  * 支付宝v3：修复多个棋盘密云接口的必传参数和响应结构体字段，确保与官方文档一致。
-
-
+    * gopay：golang.org/x/crypto 版本升级到 v0.48.0。
+    * gopay：golang module 版本升级到 go 1.24.0。
+    * 微信v3：新增 wechat.GetOauth2AccessToken()，返回参数新增 is_snapshotuser 字段。
+    * 支付宝v3：新增 client.MerchantItemFileUpload()，商家商品文件上传接口。
+    * 支付宝v3：新增 棋盘密云 相关接口。
+        * client.MerchantQipanCrowdCreate()，上传创建人群。
+        * client.MerchantQipanCrowdUserAdd()，人群中追加用户。
+        * client.MerchantQipanCrowdUserDelete()，人群中删除用户。
+        * client.MarketingQipanTagBaseBatchQuery()，棋盘人群圈选标签基本信息查询。
+        * client.MarketingQipanTagQuery()，棋盘标签圈选值查询。
+        * client.MarketingQipanCrowdBatchQuery()，查询人群列表。
+        * client.MarketingQipanCrowdQuery()，查询人群详情。
+        * client.MarketingQipanCrowdModify()，修改人群。
+        * client.MerchantQipanCrowdPoolCreate()，人群池创建。
+        * client.MerchantQipanCrowdSpread()，人群扩展接口。
+        * client.MerchantQipanGreyBlackCrowdCreate()，上传创建灰黑产人群。
+        * client.MerchantQipanGreyBlackCrowdUserAdd()，灰黑产人群中追加用户。
+        * client.MerchantQipanGreyBlackCrowdUserDelete()，灰黑产人群中删除用户。
+    * 支付宝v3：新增 client.MarketingCampaignOrderVoucherConsult()，订单优惠前置咨询接口。
+    * 支付宝v3：删除已下架接口 client.MarketingQipanCrowdOperationCreate()。
+    * 支付宝v3：修复多个棋盘密云接口的必传参数和响应结构体字段，确保与官方文档一致。
 
 ## 版本号：v1.5.114
 
 * 修改记录：
-  * gopay：golang.org/x/crypto 版本升级到 v0.39.0。
-  * 支付宝v3：新增 client.TradeAppPay()，支付宝APP支付（v2版本）。
-  * 支付宝v3：新增 client.TradePagePay()，统一收单下单并支付页面接口（v2版本）。
-  * 支付宝v3：修复上传文件相关接口签名错误问题。
-  * 支付宝v3：新增 小程序开发相关接口。
-    * client.OpenMiniVersionAuditedCancel()，小程序退回开发。
-    * client.OpenMiniVersionGrayOnline()，小程序灰度上架。
-    * client.OpenMiniVersionGrayCancel()，小程序结束灰度。
-    * client.OpenMiniVersionOnline()，小程序上架。
-    * client.OpenMiniVersionOffline()，小程序下架。
-    * client.OpenMiniVersionRollback()，小程序回滚。
-    * client.OpenMiniVersionDelete()，小程序删除版本。
-    * client.OpenMiniVersionAuditApply()，小程序提交审核。
-    * client.OpenMiniVersionUpload()，小程序基于模板上传版本。
-    * client.OpenMiniTemplateUsageQuery()，查询使用模板的小程序列表。
-    * client.OpenMiniVersionBuildQuery()，小程序查询版本构建状态。
-    * client.OpenMiniVersionDetailQuery()，小程序版本详情查询。
-    * client.OpenMiniVersionListQuery()，小程序版本列表查询。
-    * client.OpenMiniExperienceCreate()，小程序生成体验版。
-    * client.OpenMiniExperienceQuery()，小程序体验版状态查询接口。
-    * client.OpenMiniExperienceCancel()，小程序取消体验版。
+    * gopay：golang.org/x/crypto 版本升级到 v0.39.0。
+    * 支付宝v3：新增 client.TradeAppPay()，支付宝APP支付（v2版本）。
+    * 支付宝v3：新增 client.TradePagePay()，统一收单下单并支付页面接口（v2版本）。
+    * 支付宝v3：修复上传文件相关接口签名错误问题。
+    * 支付宝v3：新增 小程序开发相关接口。
+        * client.OpenMiniVersionAuditedCancel()，小程序退回开发。
+        * client.OpenMiniVersionGrayOnline()，小程序灰度上架。
+        * client.OpenMiniVersionGrayCancel()，小程序结束灰度。
+        * client.OpenMiniVersionOnline()，小程序上架。
+        * client.OpenMiniVersionOffline()，小程序下架。
+        * client.OpenMiniVersionRollback()，小程序回滚。
+        * client.OpenMiniVersionDelete()，小程序删除版本。
+        * client.OpenMiniVersionAuditApply()，小程序提交审核。
+        * client.OpenMiniVersionUpload()，小程序基于模板上传版本。
+        * client.OpenMiniTemplateUsageQuery()，查询使用模板的小程序列表。
+        * client.OpenMiniVersionBuildQuery()，小程序查询版本构建状态。
+        * client.OpenMiniVersionDetailQuery()，小程序版本详情查询。
+        * client.OpenMiniVersionListQuery()，小程序版本列表查询。
+        * client.OpenMiniExperienceCreate()，小程序生成体验版。
+        * client.OpenMiniExperienceQuery()，小程序体验版状态查询接口。
+        * client.OpenMiniExperienceCancel()，小程序取消体验版。
 
 ## 版本号：v1.5.113
 
 * 修改记录：
-  * 微信v3：修正接口 client.V3ComplaintImage() 的数据返回，新增 ImageData bytes。
-  * 支付宝v3：新增 商家活动券 相关接口。
-    * client.MarketingActivityOrderVoucherCreate()，创建商家活动券。
-    * client.MarketingActivityOrderVoucherCodeDeposit()，同步商家券券码。
-    * client.MarketingActivityOrderVoucherModify()，修改商家活动券基本信息。
-    * client.MarketingActivityOrderVoucherStop()，停止商家活动券。
-    * client.MarketingActivityOrderVoucherAppend()，修改商家活动券发券数量上限。
-    * client.MarketingActivityOrderVoucherUse()，同步券核销状态。
-    * client.MarketingActivityOrderVoucherRefund()，取消券核销状态。
-    * client.MarketingActivityConsult()，活动领取咨询接口。
-    * client.MarketingActivityOrderVoucherQuery()，查询商家活动券。
-    * client.MarketingActivityQuery()，查询活动详情。
-    * client.MarketingActivityOrderVoucherCodeCount()，统计商家券券码数量。
-    * client.MarketingActivityBatchQuery()，条件查询活动列表。
-    * client.MarketingActivityQueryUserBatchQueryVoucher()，条件查询用户券。
-    * client.MarketingActivityQueryUserQueryVoucher()，查询用户券详情。
-    * client.MarketingActivityQueryAppBatchQuery()，查询活动可用小程序。
-    * client.MarketingActivityQueryShopBatchQuery()，查询活动可用门店。
-    * client.MarketingActivityQueryGoodsBatchQuery()，查询活动适用商品。
-  * 支付宝v3：新增 蚂蚁店铺 相关接口。
-    * client.AntMerchantShopCreate()，蚂蚁店铺创建。
-    * client.AntMerchantShopModify()，修改蚂蚁店铺。
-    * client.AntMerchantShopQuery()，店铺查询接口。
-    * client.AntMerchantShopClose()，蚂蚁店铺关闭。
-    * client.AntMerchantOrderQuery()，商户申请单查询。
-    * client.AntMerchantShopPageQuery()，店铺分页查询接口。
-    * client.AntMerchantExpandIndirectImageUpload()，图片上传。
-    * client.AntMerchantExpandMccQuery()，商户mcc信息查询。
-    * client.AntMerchantExpandShopReceiptAccountSave()，店铺增加收单账号。
-  * 支付宝v3：新增 商家会员卡 相关接口。
-    * client.MarketingCardTemplateCreate()，会员卡模板创建。
-    * client.MarketingCardTemplateQuery()，会员卡模板查询接口。
-    * client.MarketingCardTemplateModify()，会员卡模板修改。
-    * client.MarketingCardFormTemplateSet()，会员卡开卡表单模板配置。
-    * client.MarketingCardQuery()，会员卡查询。
-    * client.MarketingCardUpdate()，会员卡更新。
-    * client.MarketingCardDelete()，会员卡删卡。
-    * client.MarketingCardMessageNotify()，会员卡消息通知。
-    * client.OfflineMaterialImageUpload()，上传门店照片和视频。
-  * 支付宝v3：新增 红包 相关接口。
-    * client.FundTransRefund()，资金退回接口。
+    * 微信v3：修正接口 client.V3ComplaintImage() 的数据返回，新增 ImageData bytes。
+    * 支付宝v3：新增 商家活动券 相关接口。
+        * client.MarketingActivityOrderVoucherCreate()，创建商家活动券。
+        * client.MarketingActivityOrderVoucherCodeDeposit()，同步商家券券码。
+        * client.MarketingActivityOrderVoucherModify()，修改商家活动券基本信息。
+        * client.MarketingActivityOrderVoucherStop()，停止商家活动券。
+        * client.MarketingActivityOrderVoucherAppend()，修改商家活动券发券数量上限。
+        * client.MarketingActivityOrderVoucherUse()，同步券核销状态。
+        * client.MarketingActivityOrderVoucherRefund()，取消券核销状态。
+        * client.MarketingActivityConsult()，活动领取咨询接口。
+        * client.MarketingActivityOrderVoucherQuery()，查询商家活动券。
+        * client.MarketingActivityQuery()，查询活动详情。
+        * client.MarketingActivityOrderVoucherCodeCount()，统计商家券券码数量。
+        * client.MarketingActivityBatchQuery()，条件查询活动列表。
+        * client.MarketingActivityQueryUserBatchQueryVoucher()，条件查询用户券。
+        * client.MarketingActivityQueryUserQueryVoucher()，查询用户券详情。
+        * client.MarketingActivityQueryAppBatchQuery()，查询活动可用小程序。
+        * client.MarketingActivityQueryShopBatchQuery()，查询活动可用门店。
+        * client.MarketingActivityQueryGoodsBatchQuery()，查询活动适用商品。
+    * 支付宝v3：新增 蚂蚁店铺 相关接口。
+        * client.AntMerchantShopCreate()，蚂蚁店铺创建。
+        * client.AntMerchantShopModify()，修改蚂蚁店铺。
+        * client.AntMerchantShopQuery()，店铺查询接口。
+        * client.AntMerchantShopClose()，蚂蚁店铺关闭。
+        * client.AntMerchantOrderQuery()，商户申请单查询。
+        * client.AntMerchantShopPageQuery()，店铺分页查询接口。
+        * client.AntMerchantExpandIndirectImageUpload()，图片上传。
+        * client.AntMerchantExpandMccQuery()，商户mcc信息查询。
+        * client.AntMerchantExpandShopReceiptAccountSave()，店铺增加收单账号。
+    * 支付宝v3：新增 商家会员卡 相关接口。
+        * client.MarketingCardTemplateCreate()，会员卡模板创建。
+        * client.MarketingCardTemplateQuery()，会员卡模板查询接口。
+        * client.MarketingCardTemplateModify()，会员卡模板修改。
+        * client.MarketingCardFormTemplateSet()，会员卡开卡表单模板配置。
+        * client.MarketingCardQuery()，会员卡查询。
+        * client.MarketingCardUpdate()，会员卡更新。
+        * client.MarketingCardDelete()，会员卡删卡。
+        * client.MarketingCardMessageNotify()，会员卡消息通知。
+        * client.OfflineMaterialImageUpload()，上传门店照片和视频。
+    * 支付宝v3：新增 红包 相关接口。
+        * client.FundTransRefund()，资金退回接口。
 
 ## 版本号：v1.5.112
 
 * 修改记录：
-  * 支付宝v2：新增部分第三方应用接口。
-  * 微信v2：修正接口 client.EntrustPublic() 的数据返回。
-  * 支付宝v3：修复已知问题。
+    * 支付宝v2：新增部分第三方应用接口。
+    * 微信v2：修正接口 client.EntrustPublic() 的数据返回。
+    * 支付宝v3：修复已知问题。
 
 ## 版本号：v1.5.111
 
 * 修改记录：
-  * gopay：go mod 升级至 go 1.23.0
-  * gopay：golang.org/x/crypto 版本升级到 v0.37.0。
-  * 微信V3：删除废弃的 wechat.V3VerifySign()、notify.VerifySign() 函数和方法。
-  * 微信V3：client.verifySyncSign() 私有方法优化，证书没找到时，如果是微信支付公钥模式，直接返回报错。
-  * 支付宝v3：修复 alipay-app-auth-token 无法设置问题，提供 client.SetAppAuthToken() 方法。
-  * 支付宝v3：支持方法自定义设置 alipay-app-auth-token，bm.Set(alipay.HeaderAppAuthToken, "xxx")。
-  * 支付宝v3：新增部分接口，详情查看v3文档接口列表
+    * gopay：go mod 升级至 go 1.23.0
+    * gopay：golang.org/x/crypto 版本升级到 v0.37.0。
+    * 微信V3：删除废弃的 wechat.V3VerifySign()、notify.VerifySign() 函数和方法。
+    * 微信V3：client.verifySyncSign() 私有方法优化，证书没找到时，如果是微信支付公钥模式，直接返回报错。
+    * 支付宝v3：修复 alipay-app-auth-token 无法设置问题，提供 client.SetAppAuthToken() 方法。
+    * 支付宝v3：支持方法自定义设置 alipay-app-auth-token，bm.Set(alipay.HeaderAppAuthToken, "xxx")。
+    * 支付宝v3：新增部分接口，详情查看v3文档接口列表
 
 ## 版本号：v1.5.110
 
 * 修改记录：
-  * gopay：module 最低版本 go 1.22
-  * Apple：client.GetRefundHistory() 接口优化，无version时，请求query参数中不再带上version字段。
-  * 微信V3：新增 client.AutoVerifySignByPublicKey()，微信公钥自动验签。
-  * 微信V3：每个业务方法优化错误判断优先级，增加ErrResponse字段。
-  * PayPal：新增 client.SetRequestHeader()，设置自定义Header。
-  * PayPal：新增 client.ClearRequestHeader()，清除自定义Header。
-  * PayPal：新增 Subscriptions 相关接口。
-    * client.PlanList()，计划列表。
-    * client.PlanDetails()，计划详情。
-    * client.PlanUpdate()，更新计划。
-    * client.PlanActivate()，激活计划。
-    * client.PlanDeactivate()，停用计划。
-    * client.PlanUpdatePrice()，更新计划价格。
-    * client.SubscriptionCreate()，创建订阅。
-    * client.SubscriptionDetails()，订阅详情。
-    * client.SubscriptionUpdate()，更新订阅。
-    * client.SubscriptionRevise()，修改计划或订阅数量。
-    * client.SubscriptionSuspend()，暂停订阅。
-    * client.SubscriptionCancel()，取消订阅。
-    * client.SubscriptionActivate()，激活订阅。
-    * client.SubscriptionCapture()，订阅时获取授权付款。
-    * client.SubscriptionTransactionList()，订阅的交易列表。
-  * PayPal：新增 Product 相关接口。
-    * client.ProductCreate()，创建产品。
-    * client.ProductList()，产品列表。
-    * client.ProductDetails()，产品详情。
-    * client.ProductUpdate()，更新产品。
-  * 支付宝V3：新增推广计划接口
-    * client.MarketingActivityDeliveryCreate()，创建推广计划。
-    * client.MarketingActivityDeliveryQuery()，查询推广计划。
-    * client.MarketingActivityDeliveryStop()，停止推广计划。
-  * 支付宝V3：新增图片素材接口
-    * client.MarketingMaterialImageUpload()，营销图片资源上传。
+    * gopay：module 最低版本 go 1.22
+    * Apple：client.GetRefundHistory() 接口优化，无version时，请求query参数中不再带上version字段。
+    * 微信V3：新增 client.AutoVerifySignByPublicKey()，微信公钥自动验签。
+    * 微信V3：每个业务方法优化错误判断优先级，增加ErrResponse字段。
+    * PayPal：新增 client.SetRequestHeader()，设置自定义Header。
+    * PayPal：新增 client.ClearRequestHeader()，清除自定义Header。
+    * PayPal：新增 Subscriptions 相关接口。
+        * client.PlanList()，计划列表。
+        * client.PlanDetails()，计划详情。
+        * client.PlanUpdate()，更新计划。
+        * client.PlanActivate()，激活计划。
+        * client.PlanDeactivate()，停用计划。
+        * client.PlanUpdatePrice()，更新计划价格。
+        * client.SubscriptionCreate()，创建订阅。
+        * client.SubscriptionDetails()，订阅详情。
+        * client.SubscriptionUpdate()，更新订阅。
+        * client.SubscriptionRevise()，修改计划或订阅数量。
+        * client.SubscriptionSuspend()，暂停订阅。
+        * client.SubscriptionCancel()，取消订阅。
+        * client.SubscriptionActivate()，激活订阅。
+        * client.SubscriptionCapture()，订阅时获取授权付款。
+        * client.SubscriptionTransactionList()，订阅的交易列表。
+    * PayPal：新增 Product 相关接口。
+        * client.ProductCreate()，创建产品。
+        * client.ProductList()，产品列表。
+        * client.ProductDetails()，产品详情。
+        * client.ProductUpdate()，更新产品。
+    * 支付宝V3：新增推广计划接口
+        * client.MarketingActivityDeliveryCreate()，创建推广计划。
+        * client.MarketingActivityDeliveryQuery()，查询推广计划。
+        * client.MarketingActivityDeliveryStop()，停止推广计划。
+    * 支付宝V3：新增图片素材接口
+        * client.MarketingMaterialImageUpload()，营销图片资源上传。
 
 ## 版本号：v1.5.109
 
 * 修改记录：
-  * gopay：golang.org/x/crypto 版本升级到 v0.33.0。
-  * 支付宝：作废 client.UserAgreementPageSignInApp() 方法，使用 client.UserAgreementPageSignInQRCode() 方法替换。
-  * 支付宝：修改 client.FundTransAppPay() 方法返回参数。
-  * PayPal：新增 Payment Method Tokens 相关接口。
-  * PayPal：新增 client.WithoutAutoRefreshToken() 方法，不自动刷新token。
-  * 支付宝V3：新增 商家转账 相关的接口。
-    * client.FundAccountQuery()，支付宝资金账户资产查询接口。
-    * client.FundQuotaQuery()，转账额度查询接口。
-    * client.FundTransUniTransfer()，单笔转账接口。
-    * client.DataBillEreceiptApply()，申请电子回单(incubating)。
-    * client.DataBillEreceiptQuery()，查询电子回单状态(incubating)。
-    * client.FundTransCommonQuery()，转账业务单据查询接口。
-    * client.FundTransMultistepTransfer()，多步转账创建并支付。
-    * client.FundTransMultistepQuery()，多步转账查询接口。
+    * gopay：golang.org/x/crypto 版本升级到 v0.33.0。
+    * 支付宝：作废 client.UserAgreementPageSignInApp() 方法，使用 client.UserAgreementPageSignInQRCode() 方法替换。
+    * 支付宝：修改 client.FundTransAppPay() 方法返回参数。
+    * PayPal：新增 Payment Method Tokens 相关接口。
+    * PayPal：新增 client.WithoutAutoRefreshToken() 方法，不自动刷新token。
+    * 支付宝V3：新增 商家转账 相关的接口。
+        * client.FundAccountQuery()，支付宝资金账户资产查询接口。
+        * client.FundQuotaQuery()，转账额度查询接口。
+        * client.FundTransUniTransfer()，单笔转账接口。
+        * client.DataBillEreceiptApply()，申请电子回单(incubating)。
+        * client.DataBillEreceiptQuery()，查询电子回单状态(incubating)。
+        * client.FundTransCommonQuery()，转账业务单据查询接口。
+        * client.FundTransMultistepTransfer()，多步转账创建并支付。
+        * client.FundTransMultistepQuery()，多步转账查询接口。
 
 ## 版本号：v1.5.108
 
 * 修改记录：
-  * gopay：golang.org/x/crypto 版本升级到 v0.32.0。
-  * 微信V3：支持设置代理 Host 地址，client.SetProxyHost()，wechat.SetProxyHost()。
-  * 微信V3：已支持新版本商家转账相关接口。
-    * client.V3TransferBills()，发起转账。
-    * client.V3TransferBillsCancel()，撤销转账。
-    * client.V3TransferBillsMerchantQuery()，商户单号查询转账单。
-    * client.V3TransferBillsQuery()，微信单号查询转账单。
-    * client.V3TransferElecsignMerchant()，商户单号申请电子回单。
-    * client.V3TransferElecsign()，微信单号申请电子回单。
-    * client.V3TransferElecsignQuery()，微信单号查询电子回单。
-    * client.V3TransferElecsignMerchantQuery()，商户单号查询电子回单。
-    * notify.DecryptTransferBillsNotifyCipherText()，解密 新版商家转账通知 回调中的加密参数。
-  * 支付宝V3：支持设置代理 Host 地址，client.SetProxyHost()。
-  * 补充部分支付宝V3接口。
-  * 支付宝V3：处理公共参数方法 a.pubParamsHandle() 内逻辑变更，优先判断非body map内的参数赋值。
+    * gopay：golang.org/x/crypto 版本升级到 v0.32.0。
+    * 微信V3：支持设置代理 Host 地址，client.SetProxyHost()，wechat.SetProxyHost()。
+    * 微信V3：已支持新版本商家转账相关接口。
+        * client.V3TransferBills()，发起转账。
+        * client.V3TransferBillsCancel()，撤销转账。
+        * client.V3TransferBillsMerchantQuery()，商户单号查询转账单。
+        * client.V3TransferBillsQuery()，微信单号查询转账单。
+        * client.V3TransferElecsignMerchant()，商户单号申请电子回单。
+        * client.V3TransferElecsign()，微信单号申请电子回单。
+        * client.V3TransferElecsignQuery()，微信单号查询电子回单。
+        * client.V3TransferElecsignMerchantQuery()，商户单号查询电子回单。
+        * notify.DecryptTransferBillsNotifyCipherText()，解密 新版商家转账通知 回调中的加密参数。
+    * 支付宝V3：支持设置代理 Host 地址，client.SetProxyHost()。
+    * 补充部分支付宝V3接口。
+    * 支付宝V3：处理公共参数方法 a.pubParamsHandle() 内逻辑变更，优先判断非body map内的参数赋值。
 
 ## 版本号：v1.5.107
 
 * 修改记录：
-  * gopay：golang.org/x/crypto 版本升级到 v0.31.0。
-  * gopay：xhttp transport 的默认 MaxIdleConnsPerHost 设置为 1000，MaxConnsPerHost 设置为 3000。
-  * 微信V3：新增掌纹支付相关接口。
-  * 微信V3：补充 支付有礼相关接口。
-  * 微信V3：补充 电子发票相关接口。
-  * 支付宝V3：补充 支付宝的若干v3接口。
+    * gopay：golang.org/x/crypto 版本升级到 v0.31.0。
+    * gopay：xhttp transport 的默认 MaxIdleConnsPerHost 设置为 1000，MaxConnsPerHost 设置为 3000。
+    * 微信V3：新增掌纹支付相关接口。
+    * 微信V3：补充 支付有礼相关接口。
+    * 微信V3：补充 电子发票相关接口。
+    * 支付宝V3：补充 支付宝的若干v3接口。
 
 ## 版本号：v1.5.106
 
 * 修改记录：
-  * 支付宝：支付宝支持V3接口，接口还在完善中，欢迎提PR一起建设。
-  * gopay：支付宝、微信接口请求支持设置自定义RequestId的函数，client.SetRequestIdFunc()。
-  * gopay：修复部分已知问题。
+    * 支付宝：支付宝支持V3接口，接口还在完善中，欢迎提PR一起建设。
+    * gopay：支付宝、微信接口请求支持设置自定义RequestId的函数，client.SetRequestIdFunc()。
+    * gopay：修复部分已知问题。
 
 ## 版本号：v1.5.105
 
 * 修改记录：
-  * gopay：golang.org/x/crypto v0.26.0 版本升级到 v0.27.0。
-  * 支付宝：新增 client.MarketingCampaignCashCreate()，创建现金活动接口。
-  * 支付宝：新增 client.MarketingCampaignCashTrigger()，触发现金红包活动接口。
-  * 支付宝：新增 client.MarketingCampaignCashStatusModify()，更改现金活动状态接口。
-  * 支付宝：新增 client.MarketingCampaignCashListQuery()，现金活动列表查询接口。
-  * 支付宝：新增 client.MarketingCampaignCashDetailQuery()，现金活动详情查询接口。
-  * 支付宝：新增 client.MerchantQipanCrowdCreate()，上传创建人群接口。
-  * 支付宝：新增 client.MerchantQipanCrowdUserAdd()，人群中追加用户接口。
-  * 支付宝：新增 client.MerchantQipanCrowdUserDelete()，人群中删除用户接口。
-  * 支付宝：新增 client.MarketingQipanTagBaseBatchQuery()，棋盘人群圈选标签基本信息查询接口。
-  * 支付宝：新增 client.MarketingQipanTagQuery()，棋盘标签圈选值查询接口。
-  * 支付宝：新增 client.MarketingQipanCrowdOperationCreate()，棋盘人群创建接口。
-  * 支付宝：新增 client.MarketingQipanCrowdTagQuery()，查询圈选标签列表接口。
-  * 支付宝：新增 client.MarketingQipanCrowdWithTagCreate()，标签圈选创建人群接口。
-  * 支付宝：新增 client.MarketingQipanCrowdWithTagQuery()，标签圈选预估人群规模接口。
-  * 支付宝：新增 client.MarketingQipanCrowdBatchQuery()，查询人群列表接口。
-  * 支付宝：新增 client.MarketingQipanCrowdQuery()，查询人群详情接口。
-  * 支付宝：新增 client.MarketingQipanCrowdModify()，修改人群接口。
-  * 支付宝：新增 client.MarketingQipanBoardQuery()，看板分析接口。
-  * 支付宝：新增 client.MarketingQipanInsightQuery()，画像分析接口。
-  * 支付宝：新增 client.MarketingQipanBehaviorQuery()，行为分析接口。
-  * 支付宝：新增 client.MarketingQipanTrendQuery()，趋势分析接口。
-  * 支付宝：新增 client.MarketingQipanInsightCityQuery()，常住省市查询接口。
-  * PayPal：新增 client.AddTrackingNumber()，添加物流单号接口。
-  * PayPal：优化部分结构体字段。。
-  * 支付宝：FundTransCommonQuery 结构体补充字段。
-  * Apple：client.SendConsumptionInformation() 方法成功状态码判断修改。
-  * gopay：升级内部依赖module库。
+    * gopay：golang.org/x/crypto v0.26.0 版本升级到 v0.27.0。
+    * 支付宝：新增 client.MarketingCampaignCashCreate()，创建现金活动接口。
+    * 支付宝：新增 client.MarketingCampaignCashTrigger()，触发现金红包活动接口。
+    * 支付宝：新增 client.MarketingCampaignCashStatusModify()，更改现金活动状态接口。
+    * 支付宝：新增 client.MarketingCampaignCashListQuery()，现金活动列表查询接口。
+    * 支付宝：新增 client.MarketingCampaignCashDetailQuery()，现金活动详情查询接口。
+    * 支付宝：新增 client.MerchantQipanCrowdCreate()，上传创建人群接口。
+    * 支付宝：新增 client.MerchantQipanCrowdUserAdd()，人群中追加用户接口。
+    * 支付宝：新增 client.MerchantQipanCrowdUserDelete()，人群中删除用户接口。
+    * 支付宝：新增 client.MarketingQipanTagBaseBatchQuery()，棋盘人群圈选标签基本信息查询接口。
+    * 支付宝：新增 client.MarketingQipanTagQuery()，棋盘标签圈选值查询接口。
+    * 支付宝：新增 client.MarketingQipanCrowdOperationCreate()，棋盘人群创建接口。
+    * 支付宝：新增 client.MarketingQipanCrowdTagQuery()，查询圈选标签列表接口。
+    * 支付宝：新增 client.MarketingQipanCrowdWithTagCreate()，标签圈选创建人群接口。
+    * 支付宝：新增 client.MarketingQipanCrowdWithTagQuery()，标签圈选预估人群规模接口。
+    * 支付宝：新增 client.MarketingQipanCrowdBatchQuery()，查询人群列表接口。
+    * 支付宝：新增 client.MarketingQipanCrowdQuery()，查询人群详情接口。
+    * 支付宝：新增 client.MarketingQipanCrowdModify()，修改人群接口。
+    * 支付宝：新增 client.MarketingQipanBoardQuery()，看板分析接口。
+    * 支付宝：新增 client.MarketingQipanInsightQuery()，画像分析接口。
+    * 支付宝：新增 client.MarketingQipanBehaviorQuery()，行为分析接口。
+    * 支付宝：新增 client.MarketingQipanTrendQuery()，趋势分析接口。
+    * 支付宝：新增 client.MarketingQipanInsightCityQuery()，常住省市查询接口。
+    * PayPal：新增 client.AddTrackingNumber()，添加物流单号接口。
+    * PayPal：优化部分结构体字段。。
+    * 支付宝：FundTransCommonQuery 结构体补充字段。
+    * Apple：client.SendConsumptionInformation() 方法成功状态码判断修改。
+    * gopay：升级内部依赖module库。
 
 ## 版本号：Release 1.5.104
 
 * 修改记录：
-  * gopay：golang.org/x/crypto v0.24.0 版本升级到 v0.26.0。
-  * 支付宝：client.TradeOrderSettle()，response 完善字段。
-  * 微信V3：新增 client.V3QQTransactionH5()，QQ小程序H5下单。
-  * 微信V3：新增 client.V3CombineQQTransactionH5()，合单QQ小程序下单-H5。
-  * 微信V3：新增 wechat.V3DecryptViolationNotifyCipherText()，解密 服务商子商户处置记录 回调中的加密信息。#412
-  * 微信V3：新增 V3NotifyReq method req.DecryptViolationCipherText()，解密 服务商子商户处置记录 回调中的加密信息。
-  * 微信V3：新增 wechat.V3DecryptTransferBatchNotifyCipherText()，解密 商家转账批次回调通知 回调中的加密信息。
-  * 微信V3：新增 V3NotifyReq method req.DecryptTransferBatchCipherText()，解密 商家转账批次回调通知 回调中的加密信息。
-  * 支付宝：新增 client.MarketingCardTemplateCreate()，会员卡模板创建接口。
-  * 支付宝：新增 client.MarketingCardTemplateModify()，会员卡模板修改接口。
-  * 支付宝：新增 client.MarketingCardTemplateQuery()，会员卡模板查询接口。
-  * 支付宝：新增 client.MarketingCardUpdate()，会员卡更新接口。
-  * 支付宝：新增 client.MarketingCardQuery()，会员卡查询接口。
-  * 支付宝：新增 client.MarketingCardDelete()，会员卡删卡接口。
-  * 支付宝：新增 client.MarketingCardMessageNotify()，会员卡消息通知接口。
-  * 支付宝：新增 client.MarketingCardFormTemplateSet()，会员卡开卡表单模板配置接口。
-  * 支付宝：新增 client.OfflineMaterialImageUpload()，上传门店照片和视频接口。
+    * gopay：golang.org/x/crypto v0.24.0 版本升级到 v0.26.0。
+    * 支付宝：client.TradeOrderSettle()，response 完善字段。
+    * 微信V3：新增 client.V3QQTransactionH5()，QQ小程序H5下单。
+    * 微信V3：新增 client.V3CombineQQTransactionH5()，合单QQ小程序下单-H5。
+    * 微信V3：新增 wechat.V3DecryptViolationNotifyCipherText()，解密 服务商子商户处置记录 回调中的加密信息。#412
+    * 微信V3：新增 V3NotifyReq method req.DecryptViolationCipherText()，解密 服务商子商户处置记录 回调中的加密信息。
+    * 微信V3：新增 wechat.V3DecryptTransferBatchNotifyCipherText()，解密 商家转账批次回调通知 回调中的加密信息。
+    * 微信V3：新增 V3NotifyReq method req.DecryptTransferBatchCipherText()，解密 商家转账批次回调通知 回调中的加密信息。
+    * 支付宝：新增 client.MarketingCardTemplateCreate()，会员卡模板创建接口。
+    * 支付宝：新增 client.MarketingCardTemplateModify()，会员卡模板修改接口。
+    * 支付宝：新增 client.MarketingCardTemplateQuery()，会员卡模板查询接口。
+    * 支付宝：新增 client.MarketingCardUpdate()，会员卡更新接口。
+    * 支付宝：新增 client.MarketingCardQuery()，会员卡查询接口。
+    * 支付宝：新增 client.MarketingCardDelete()，会员卡删卡接口。
+    * 支付宝：新增 client.MarketingCardMessageNotify()，会员卡消息通知接口。
+    * 支付宝：新增 client.MarketingCardFormTemplateSet()，会员卡开卡表单模板配置接口。
+    * 支付宝：新增 client.OfflineMaterialImageUpload()，上传门店照片和视频接口。
 
 ## 版本号：Release 1.5.103
 
 * 修改记录：
-  * gopay：xlog 库更新，支持接口自定义logger。
-  * gopay：go mod 版本升级至 1.21。
-  * 支付宝：新增 client.PayAppMarketingConsult()，商户前置内容咨询接口。
-  * 支付宝：新增 client.MarketingActivityOrderVoucherCreate()，创建商家券活动接口
-  * 支付宝：新增 client.MarketingActivityOrderVoucherCodeDeposit()，同步商家券券码接口
-  * 支付宝：新增 client.MarketingActivityOrderVoucherModify()，修改商家券活动基本信息接口
-  * 支付宝：新增 client.MarketingActivityOrderVoucherStop()，停止商家券活动接口
-  * 支付宝：新增 client.MarketingActivityOrderVoucherAppend()，修改商家券活动发券数量上限接口
-  * 支付宝：新增 client.MarketingActivityOrderVoucherUse()，同步券核销状态接口
-  * 支付宝：新增 client.MarketingActivityOrderVoucherRefund()，取消券核销状态接口
-  * 支付宝：新增 client.MarketingActivityOrderVoucherQuery()，查询商家券活动接口
-  * 支付宝：新增 client.MarketingActivityOrderVoucherCodeCount()，统计商家券券码数量接口
+    * gopay：xlog 库更新，支持接口自定义logger。
+    * gopay：go mod 版本升级至 1.21。
+    * 支付宝：新增 client.PayAppMarketingConsult()，商户前置内容咨询接口。
+    * 支付宝：新增 client.MarketingActivityOrderVoucherCreate()，创建商家券活动接口
+    * 支付宝：新增 client.MarketingActivityOrderVoucherCodeDeposit()，同步商家券券码接口
+    * 支付宝：新增 client.MarketingActivityOrderVoucherModify()，修改商家券活动基本信息接口
+    * 支付宝：新增 client.MarketingActivityOrderVoucherStop()，停止商家券活动接口
+    * 支付宝：新增 client.MarketingActivityOrderVoucherAppend()，修改商家券活动发券数量上限接口
+    * 支付宝：新增 client.MarketingActivityOrderVoucherUse()，同步券核销状态接口
+    * 支付宝：新增 client.MarketingActivityOrderVoucherRefund()，取消券核销状态接口
+    * 支付宝：新增 client.MarketingActivityOrderVoucherQuery()，查询商家券活动接口
+    * 支付宝：新增 client.MarketingActivityOrderVoucherCodeCount()，统计商家券券码数量接口
 
 ## 版本号：Release 1.5.102
 
 * 修改记录：
-  * gopay：golang.org/x/crypto v0.23.0 版本升级到 v0.24.0。
-  * 微信V3：client.V3Refund() 返回值修复错误结构。
-  * 支付宝：新增 client.AntMerchantShopPageQuery()，店铺分页查询接口。
-  * 支付宝：新增 client.AntMerchantExpandMccQuery()，商户mcc信息查询接口。
-  * 支付宝：新增 client.AntMerchantExpandShopReceiptAccountSave()，店铺增加收单账号接口。
-  * 支付宝：新增 client.DataBillEreceiptApply()，申请电子回单(incubating)接口。
-  * 支付宝：新增 client.DataBillEreceiptQuery()，查询电子回单状态(incubating)接口。
-  * 支付宝：新增 client.FaceVerificationInitialize()，APP人脸核身初始化接口。
-  * 支付宝：新增 client.FaceVerificationQuery()，APP人脸核身结果查询接口。
-  * 支付宝：新增 client.FaceCertifyInitialize()，H5人脸核身初始化接口。
-  * 支付宝：新增 client.FaceCertifyVerify()，H5人脸核身开始认证接口。
-  * 支付宝：新增 client.FaceCertifyQuery()，H5人脸核身查询记录接口。
-  * 支付宝：新增 client.FaceSourceCertify()，纯服务端人脸核身接口。
-  * 支付宝：新增 client.FaceCheckInitialize()，人脸检测初始化接口。
-  * 支付宝：新增 client.FaceCheckQuery()，人脸检测结果数据查询接口。
-  * 支付宝：新增 client.OcrServerDetect()，服务端OCR接口。
-  * 支付宝：新增 client.OcrMobileInitialize()，App端OCR初始化接口。
-  * 支付宝：新增 client.OcrCommonDetect()，文字识别OCR接口。
+    * gopay：golang.org/x/crypto v0.23.0 版本升级到 v0.24.0。
+    * 微信V3：client.V3Refund() 返回值修复错误结构。
+    * 支付宝：新增 client.AntMerchantShopPageQuery()，店铺分页查询接口。
+    * 支付宝：新增 client.AntMerchantExpandMccQuery()，商户mcc信息查询接口。
+    * 支付宝：新增 client.AntMerchantExpandShopReceiptAccountSave()，店铺增加收单账号接口。
+    * 支付宝：新增 client.DataBillEreceiptApply()，申请电子回单(incubating)接口。
+    * 支付宝：新增 client.DataBillEreceiptQuery()，查询电子回单状态(incubating)接口。
+    * 支付宝：新增 client.FaceVerificationInitialize()，APP人脸核身初始化接口。
+    * 支付宝：新增 client.FaceVerificationQuery()，APP人脸核身结果查询接口。
+    * 支付宝：新增 client.FaceCertifyInitialize()，H5人脸核身初始化接口。
+    * 支付宝：新增 client.FaceCertifyVerify()，H5人脸核身开始认证接口。
+    * 支付宝：新增 client.FaceCertifyQuery()，H5人脸核身查询记录接口。
+    * 支付宝：新增 client.FaceSourceCertify()，纯服务端人脸核身接口。
+    * 支付宝：新增 client.FaceCheckInitialize()，人脸检测初始化接口。
+    * 支付宝：新增 client.FaceCheckQuery()，人脸检测结果数据查询接口。
+    * 支付宝：新增 client.OcrServerDetect()，服务端OCR接口。
+    * 支付宝：新增 client.OcrMobileInitialize()，App端OCR初始化接口。
+    * 支付宝：新增 client.OcrCommonDetect()，文字识别OCR接口。
 
 ## 版本号：Release 1.5.101
 
 * 修改记录：
-  * gopay：golang.org/x/crypto v0.20.0 版本升级到 v0.23.0。
-  * gopay：xhttp移除外部依赖，修复文件上传相关接口的Bug。
-  * 微信V3：新增 client.V3AbnormalRefund()，发起异常退款。
-  * 微信V3：新增 client.V3FavorCallbackUrl()，查询消息通知地址。
-  * 微信V3：新增 client.V3ComplaintImage()，商户反馈图片请求接口。
-  * 微信V3：修改 wechat.V3DecryptNotifyCipherText() -> wechat.V3DecryptPayNotifyCipherText()，解密 普通支付 回调中的加密信息
-  * 微信V3：修改 wechat.DecryptPartnerCipherText() -> wechat.DecryptPartnerPayCipherText()，解密 普通支付 回调中的加密信息
-  * 微信V3：新增 wechat.V3DecryptNotifyCipherTextToStruct()，解密 统一数据 到指针结构体对象。
-  * 支付宝：新增 client.ZolozAuthenticationSmilepayInit()，刷脸支付初始化接口。
-  * 支付宝：新增 client.ZolozAuthenticationCustomerFtokenQuery()，查询刷脸结果信息接口。
-  * 支付宝：新增 client.MarketingActivityDeliveryChanged()，推广计划状态变更消息接口。
-  * 支付宝：新增 client.MarketingActivityDeliveryCreate()，创建推广计划接口。
-  * 支付宝：新增 client.MarketingActivityDeliveryQuery()，查询推广计划接口。
-  * 支付宝：新增 client.MarketingActivityDeliveryStop()，停止推广计划接口。
-  * 支付宝：新增 client.MarketingMaterialImageUpload()，营销图片资源上传接口。
-  * 支付宝：新增 client.AntMerchantExpandIndirectImageUpload()，图片上传接口。
+    * gopay：golang.org/x/crypto v0.20.0 版本升级到 v0.23.0。
+    * gopay：xhttp移除外部依赖，修复文件上传相关接口的Bug。
+    * 微信V3：新增 client.V3AbnormalRefund()，发起异常退款。
+    * 微信V3：新增 client.V3FavorCallbackUrl()，查询消息通知地址。
+    * 微信V3：新增 client.V3ComplaintImage()，商户反馈图片请求接口。
+    * 微信V3：修改 wechat.V3DecryptNotifyCipherText() -> wechat.V3DecryptPayNotifyCipherText()，解密 普通支付 回调中的加密信息
+    * 微信V3：修改 wechat.DecryptPartnerCipherText() -> wechat.DecryptPartnerPayCipherText()，解密 普通支付 回调中的加密信息
+    * 微信V3：新增 wechat.V3DecryptNotifyCipherTextToStruct()，解密 统一数据 到指针结构体对象。
+    * 支付宝：新增 client.ZolozAuthenticationSmilepayInit()，刷脸支付初始化接口。
+    * 支付宝：新增 client.ZolozAuthenticationCustomerFtokenQuery()，查询刷脸结果信息接口。
+    * 支付宝：新增 client.MarketingActivityDeliveryChanged()，推广计划状态变更消息接口。
+    * 支付宝：新增 client.MarketingActivityDeliveryCreate()，创建推广计划接口。
+    * 支付宝：新增 client.MarketingActivityDeliveryQuery()，查询推广计划接口。
+    * 支付宝：新增 client.MarketingActivityDeliveryStop()，停止推广计划接口。
+    * 支付宝：新增 client.MarketingMaterialImageUpload()，营销图片资源上传接口。
+    * 支付宝：新增 client.AntMerchantExpandIndirectImageUpload()，图片上传接口。
 
 ## 版本号：Release 1.5.100
 
 * 修改记录：
-  * 支付宝：整理异步通知 NotifyRequest 结构体。
-  * 微信V2：新增 client.ProfitSharingOrderAmountQuery()，查询订单待分账金额。
-  * 微信V2：新增 client.ProfitSharingMerchantRatioQuery()，查询最大分账比例。
-  * gopay：依赖库整理拆分整理，go mod 版本升级到 go1.20。
-  * gopay：升级 1.5.100 版本需要伴随部分代码替换修改，谨慎升级。
-  * gopay：优化一些已知问题。
+    * 支付宝：整理异步通知 NotifyRequest 结构体。
+    * 微信V2：新增 client.ProfitSharingOrderAmountQuery()，查询订单待分账金额。
+    * 微信V2：新增 client.ProfitSharingMerchantRatioQuery()，查询最大分账比例。
+    * gopay：依赖库整理拆分整理，go mod 版本升级到 go1.20。
+    * gopay：升级 1.5.100 版本需要伴随部分代码替换修改，谨慎升级。
+    * gopay：优化一些已知问题。
 
 ## 版本号：Release 1.5.99
 
 * 修改记录：
-  * 微信V3：新增微信服务商模式支付分。
-  * PayPal：支持代理BaseURL，国内部署以代理转发请求流量。
+    * 微信V3：新增微信服务商模式支付分。
+    * PayPal：支持代理BaseURL，国内部署以代理转发请求流量。
 
 ## 版本号：Release 1.5.98
 
 * 修改记录：
-  * 支付宝：PR新增 client.PostFileAliPayAPISelfV2()，文件上传自定义方法（未做验证，不知道是否好用）。
-  * Apple：更新部分结构体字段。
-  * PayPal：增加Token的自动刷新功能。
+    * 支付宝：PR新增 client.PostFileAliPayAPISelfV2()，文件上传自定义方法（未做验证，不知道是否好用）。
+    * Apple：更新部分结构体字段。
+    * PayPal：增加Token的自动刷新功能。
 
 ## 版本号：Release 1.5.97
 
 * 修改记录：
-  * 支付宝：新增 client.TradeOrderOnSettleQuery()，分账剩余金额查询。
-  * 支付宝：新增 client.TradeRoyaltyRateQuery()，分账比例查询。
-  * 支付宝：更新部分结构体，增加 open_id 相关字段。
-  * 扫呗：新增扫呗支付方式。
-  * gopay：xhttp库升级改造。
+    * 支付宝：新增 client.TradeOrderOnSettleQuery()，分账剩余金额查询。
+    * 支付宝：新增 client.TradeRoyaltyRateQuery()，分账比例查询。
+    * 支付宝：更新部分结构体，增加 open_id 相关字段。
+    * 扫呗：新增扫呗支付方式。
+    * gopay：xhttp库升级改造。
 
 ## 版本号：Release 1.5.96
 
 * 修改记录：
-  * 拉卡拉：新增拉卡拉支付。
-  * interface{} -> any。
+    * 拉卡拉：新增拉卡拉支付。
+    * interface{} -> any。
 
 ## 版本号：Release 1.5.95
 
 * 修改记录：
-  * 支付宝：新增 client.DoAliPay()。支付宝http请求方法。
-  * Apple：苹果SDK client 化。新增多个 App Store Server API。client 模式为做严格测试（无测试信息key等信息）
+    * 支付宝：新增 client.DoAliPay()。支付宝http请求方法。
+    * Apple：苹果SDK client 化。新增多个 App Store Server API。client 模式为做严格测试（无测试信息key等信息）
 
 ## 版本号：Release 1.5.94
 
 * 修改记录：
-  * 支付宝：新增 client.TradeSettleConfirm()，统一收单确认结算接口。
-  * 微信V3：新增 client.V3MediaDownloadImage()，图片下载
-  * 微信V3：修正 查询投诉单协商历史 返回结构提结构
+    * 支付宝：新增 client.TradeSettleConfirm()，统一收单确认结算接口。
+    * 微信V3：新增 client.V3MediaDownloadImage()，图片下载
+    * 微信V3：修正 查询投诉单协商历史 返回结构提结构
 
 ## 版本号：Release 1.5.93
 
 * 修改记录：
-  * 微信V2：服务商模式下，付款码支付response新增 sub_openid、sub_is_subscribe 字段。
-  * 微信V3：新增 client.V3AsyncApply4SubModifySettlement()，(新)修改结算账户。
-  * 微信V3：新增 client.V3Apply4SubMerchantsApplication()，查询结算账户修改申请状态。
-  * 支付宝：沙箱模式网关URL替换升级成新版，沙箱调试时请跳转至新版沙箱应用。
+    * 微信V2：服务商模式下，付款码支付response新增 sub_openid、sub_is_subscribe 字段。
+    * 微信V3：新增 client.V3AsyncApply4SubModifySettlement()，(新)修改结算账户。
+    * 微信V3：新增 client.V3Apply4SubMerchantsApplication()，查询结算账户修改申请状态。
+    * 支付宝：沙箱模式网关URL替换升级成新版，沙箱调试时请跳转至新版沙箱应用。
 
 ## 版本号：Release 1.5.92
 
 * 修改记录：
-  * 微信V3：新增 client.V3ComplaintUpdateRefundProgress()，更新退款审批结果。
-  * 微信V3：查询投诉单列表/详情，返回新增字段。
-  * 微信V3：拆分model文件内结构体至不同文件内。
-  * 微信V3：删除 client.V3TransferMerchantDetailQuery()，请更换 client.V3TransferMerchantDetail()
-  * 支付宝：拆分model文件内结构体至不同文件内。
+    * 微信V3：新增 client.V3ComplaintUpdateRefundProgress()，更新退款审批结果。
+    * 微信V3：查询投诉单列表/详情，返回新增字段。
+    * 微信V3：拆分model文件内结构体至不同文件内。
+    * 微信V3：删除 client.V3TransferMerchantDetailQuery()，请更换 client.V3TransferMerchantDetail()
+    * 支付宝：拆分model文件内结构体至不同文件内。
 
 ## 版本号：Release 1.5.91
 
 * 修改记录：
-  * 通联支付：新增通联支付对接，实现基本支付及其他接口。
+    * 通联支付：新增通联支付对接，实现基本支付及其他接口。
 
 ## 版本号：Release 1.5.90
 
 * 修改记录：
-  * 微信V3：新增 client.V3BusinessPointsStatusQuery()，商圈会员待积分状态查询。
-  * 微信V3：新增 client.V3BusinessParkingSync()，商圈会员停车状态同步。
-  * 微信V3：新增 国密 支持。
-  * 微信V3：新增 微信支付分停车服务 相关接口。
-  * gopay：go mod 版本升级到 go1.18。
+    * 微信V3：新增 client.V3BusinessPointsStatusQuery()，商圈会员待积分状态查询。
+    * 微信V3：新增 client.V3BusinessParkingSync()，商圈会员停车状态同步。
+    * 微信V3：新增 国密 支持。
+    * 微信V3：新增 微信支付分停车服务 相关接口。
+    * gopay：go mod 版本升级到 go1.18。
 
 ## 版本号：Release 1.5.89
 
 * 修改记录：
-  * 微信V2：新增 签约、扣款服务 相关接口。
-  * 微信V3：新增 预扣款通知 接口。
-  * gopay：debug 模式下，增加签名字符串的输出，更新 mod 包，优化部分方法。
-  * alipay：新增 client.OpenAuthTokenAppInviteCreate()，ISV向商户发起应用授权邀约。
-  * PayPal：新增 invoice 相关接口。
+    * 微信V2：新增 签约、扣款服务 相关接口。
+    * 微信V3：新增 预扣款通知 接口。
+    * gopay：debug 模式下，增加签名字符串的输出，更新 mod 包，优化部分方法。
+    * alipay：新增 client.OpenAuthTokenAppInviteCreate()，ISV向商户发起应用授权邀约。
+    * PayPal：新增 invoice 相关接口。
 
 ## 版本号：Release 1.5.88
 
 * 修改记录：
-  * PayPal：新增 invoice 相关接口。
-  * gopay：更新 mod 包，优化部分方法。
-  * alipay：修改过期时间字段类型为 int。
+    * PayPal：新增 invoice 相关接口。
+    * gopay：更新 mod 包，优化部分方法。
+    * alipay：修改过期时间字段类型为 int。
 
 ## 版本号：Release 1.5.87
 
 * 修改记录：
-  * 微信V3：新增小程序调起支付分所需要的支付参数方法：client.PaySignOfAppletScore()。
-  * 微信V3：异步通知解析方法接收BodySize大小调至5MB。
-  * 支付宝：统一收单交易退款接口，response补充接收字段。
-  * 支付宝：alipay.SystemOauthToken() 接口增加可变参数 AppAuthToken 字段，如需要时可传。
+    * 微信V3：新增小程序调起支付分所需要的支付参数方法：client.PaySignOfAppletScore()。
+    * 微信V3：异步通知解析方法接收BodySize大小调至5MB。
+    * 支付宝：统一收单交易退款接口，response补充接收字段。
+    * 支付宝：alipay.SystemOauthToken() 接口增加可变参数 AppAuthToken 字段，如需要时可传。
 
 ## 版本号：Release 1.5.86
 
 * 修改记录：
-  * 微信V3：优化异步验签方法，v3NotifyReq.VerifySignByPKMap()，通过证书Map自动选择相应的证书验签。
-  * 微信V3：微信平台证书获取方法变更，client.WxPublicKey() 获取最新微信平台证书；client.WxPublicKeyMap()，获取微信平台证书Map。
-  * 支付宝：修复 app_auth_token 的问题。
+    * 微信V3：优化异步验签方法，v3NotifyReq.VerifySignByPKMap()，通过证书Map自动选择相应的证书验签。
+    * 微信V3：微信平台证书获取方法变更，client.WxPublicKey() 获取最新微信平台证书；client.WxPublicKeyMap()，获取微信平台证书Map。
+    * 支付宝：修复 app_auth_token 的问题。
 
 ## 版本号：Release 1.5.85
 
 * 修改记录：
-  * 微信V3：修复自动验签的bug
+    * 微信V3：修复自动验签的bug
 
 ## 版本号：Release 1.5.84
 
 * 修改记录：
-  * 微信V3：优化微信平台证书的获取和选择
-  * gopay：新增 retry 工具类包
+    * 微信V3：优化微信平台证书的获取和选择
+    * gopay：新增 retry 工具类包
 
 ## 版本号：Release 1.5.83
 
 * 修改记录：
-  * alipay：新增商家分账相关接口
-  * alipay：更新部分注释上的接口文档地址。
+    * alipay：新增商家分账相关接口
+    * alipay：更新部分注释上的接口文档地址。
 
 ## 版本号：Release 1.5.82
 
 * 修改记录：
-  * gopay：xhttp库增加BodySize的自定义化设置，各支付渠道 Client 增加 client.SetBodySize() 方法。
-  * gopay：xlog 支持自定义实现接口。
-  * apple：修改结构体字段 `revocationReason` 类型。
+    * gopay：xhttp库增加BodySize的自定义化设置，各支付渠道 Client 增加 client.SetBodySize() 方法。
+    * gopay：xlog 支持自定义实现接口。
+    * apple：修改结构体字段 `revocationReason` 类型。
 
 ## 版本号：Release 1.5.81
 
 * 修改记录：
-  * 微信V3：签名方法，统一判断请求时path后缀是否为 ?，修复当bm为nil时的签名错误问题。
-  * QQ：增加了异常结果处理。
-  * 支付宝：补充了部分接口的回执参数。
+    * 微信V3：签名方法，统一判断请求时path后缀是否为 ?，修复当bm为nil时的签名错误问题。
+    * QQ：增加了异常结果处理。
+    * 支付宝：补充了部分接口的回执参数。
 
 ## 版本号：Release 1.5.80
 
 * 修改记录：
-  * PayPal：增加payout相关的v1接口
-  * PayPal：部分接口返回参数补齐
+    * PayPal：增加payout相关的v1接口
+    * PayPal：部分接口返回参数补齐
 
 ## 版本号：Release 1.5.79
 
 * 修改记录：
-  * PayPal：增加订阅相关的v1接口
-  * 微信V3：更新部分接口上注释的文档地址
-  * 支付宝：接口请求中，如下公共参数（version、return_url、notify_url、app_auth_token）支持 BodyMap 中此次请求自定义设置
+    * PayPal：增加订阅相关的v1接口
+    * 微信V3：更新部分接口上注释的文档地址
+    * 支付宝：接口请求中，如下公共参数（version、return_url、notify_url、app_auth_token）支持 BodyMap 中此次请求自定义设置
 
 ## 版本号：Release 1.5.78
 
 * 修改记录：
-  * 微信V3：V3EcommerceBalance() 缺失参数补充
-  * 微信V3：新增 client.V3EcommerceDayBalance() 方法，电商平台预约提现
-  * 微信V3：修复 银行列表获取相关接口，路由修正
-  * 微信V3：修复 client.V3BankSearchBank() 接口，私钥解密出错的问题
+    * 微信V3：V3EcommerceBalance() 缺失参数补充
+    * 微信V3：新增 client.V3EcommerceDayBalance() 方法，电商平台预约提现
+    * 微信V3：修复 银行列表获取相关接口，路由修正
+    * 微信V3：修复 client.V3BankSearchBank() 接口，私钥解密出错的问题
 
 ## 版本号：Release 1.5.77
 
 * 修改记录：
-  * 微信V3：V3EcommerceRefundQueryById()、V3EcommerceRefundQueryByNo()，缺失参数补充
-  * 微信V3：新增 client.V3EcommerceWithdraw() 方法，电商平台预约提现
-  * 微信V3：新增 client.V3EcommerceWithdrawStatus() 方法，电商平台查询预约提现状态
+    * 微信V3：V3EcommerceRefundQueryById()、V3EcommerceRefundQueryByNo()，缺失参数补充
+    * 微信V3：新增 client.V3EcommerceWithdraw() 方法，电商平台预约提现
+    * 微信V3：新增 client.V3EcommerceWithdrawStatus() 方法，电商平台查询预约提现状态
 
 ## 版本号：Release 1.5.76
 
 * 修改记录：
-  * gopay：大量优化error处理和返回，统一部分通用错误到 error.go 中
-  * 支付宝：新增 alipay.IsBizError()，判断并捕获业务错误
-  * 微信、支付宝：优化部分 error 返回格式以及透传，优化参数校验返回
+    * gopay：大量优化error处理和返回，统一部分通用错误到 error.go 中
+    * 支付宝：新增 alipay.IsBizError()，判断并捕获业务错误
+    * 微信、支付宝：优化部分 error 返回格式以及透传，优化参数校验返回
 
 ## 版本号：Release 1.5.75
 
 * 修改记录：
-  * 微信V3：client.V3Apply4SubModifySettlement()，sub_mchid 问题处理
-  * 微信V3：微信分账接收方，model参数补充添加 detail_id
-  * PayPal：注释中接口文档地址更新
-  * PayPal：新增 client.OrderConfirm()，订单确认
-  * PayPal：OrderDetail、Capture、Payer、Name 等结构体，遗漏参数补充
-  * gopay：pkg/xtime/parse_format.go，优化 DurationToUnit() 方法，int -> int64
+    * 微信V3：client.V3Apply4SubModifySettlement()，sub_mchid 问题处理
+    * 微信V3：微信分账接收方，model参数补充添加 detail_id
+    * PayPal：注释中接口文档地址更新
+    * PayPal：新增 client.OrderConfirm()，订单确认
+    * PayPal：OrderDetail、Capture、Payer、Name 等结构体，遗漏参数补充
+    * gopay：pkg/xtime/parse_format.go，优化 DurationToUnit() 方法，int -> int64
 
 ## 版本号：Release 1.5.74
 
 * 修改记录：
-  * gopay：一些小改动，util.GetRandomString() -> util.RandomString()
-  * gopay：升级 xlog
+    * gopay：一些小改动，util.GetRandomString() -> util.RandomString()
+    * gopay：升级 xlog
 
 ## 版本号：Release 1.5.73
 
 * 修改记录：
-  * Apple：新增内购支付通知V2解析
+    * Apple：新增内购支付通知V2解析
 
 ## 版本号：Release 1.5.72
 
 * 修改记录：
-  * Apple：返回参数类型错误修复，pending_renewal_info -> 数组类型
-  * QQ：获取 AccessToken 结果 expires_in 类型修复，expires_in -> 字符串类型
-  * 微信V3：证书相关代码优化
+    * Apple：返回参数类型错误修复，pending_renewal_info -> 数组类型
+    * QQ：获取 AccessToken 结果 expires_in 类型修复，expires_in -> 字符串类型
+    * 微信V3：证书相关代码优化
 
 ## 版本号：Release 1.5.71
 
 * 修改记录：
-  * 微信V2：去除所有微信小程序、公众号相关接口，请使用 wechat-sdk
-  * 支付宝：client.UserCertdocCertverifyConsult() 方法，增加 authToken 参数
-  * 微信V3：新增 银行组件（服务商） 相关接口，详情查看v3文档最下方的接口列表
+    * 微信V2：去除所有微信小程序、公众号相关接口，请使用 wechat-sdk
+    * 支付宝：client.UserCertdocCertverifyConsult() 方法，增加 authToken 参数
+    * 微信V3：新增 银行组件（服务商） 相关接口，详情查看v3文档最下方的接口列表
 
 ## 版本号：Release 1.5.69
 
 * 修改记录：
-  * 微信V3：修改 client.V3RefundQuery()、增加入参参数，适配 服务商 模式
-  * 微信V3：修复 client.V3Apply4SubSubmit()，接口路由修复
-  * gopay：BodyMap 新增 Unmarshal() 方法，解析数据到结构体、数组指针
+    * 微信V3：修改 client.V3RefundQuery()、增加入参参数，适配 服务商 模式
+    * 微信V3：修复 client.V3Apply4SubSubmit()，接口路由修复
+    * gopay：BodyMap 新增 Unmarshal() 方法，解析数据到结构体、数组指针
 
 ## 版本号：Release 1.5.68
 
 * 修改记录：
-  * 微信V3：修复 client.V3ComplaintResponse()、client.V3ComplaintComplete()， complaintId 参数类型错误问题
-  * 微信V3：新增 电商收付通（分账）相关接口，详情查看v3文档最下方的接口列表
-  * 微信V3：新增 电商收付通（补差）相关接口，详情查看v3文档最下方的接口列表
-  * 微信V3：新增 电商收付通（退款）相关接口，详情查看v3文档最下方的接口列表
-  * 微信V3：返回参数中字段，ID写法全部改写为Id写法
+    * 微信V3：修复 client.V3ComplaintResponse()、client.V3ComplaintComplete()， complaintId 参数类型错误问题
+    * 微信V3：新增 电商收付通（分账）相关接口，详情查看v3文档最下方的接口列表
+    * 微信V3：新增 电商收付通（补差）相关接口，详情查看v3文档最下方的接口列表
+    * 微信V3：新增 电商收付通（退款）相关接口，详情查看v3文档最下方的接口列表
+    * 微信V3：返回参数中字段，ID写法全部改写为Id写法
 
 ## 版本号：Release 1.5.67
 
 * 修改记录：
-  * 微信V3：配合微信文档修改，拆分服务商 批量转账 相关接口，接口如下：
-  * 微信V3：新增 client.V3PartnerTransfer()
-  * 微信V3：新增 client.V3PartnerTransferQuery()
-  * 微信V3：新增 client.V3PartnerTransferDetail()
-  * 微信V3：新增 client.V3PartnerTransferMerchantQuery()
-  * 微信V3：新增 client.V3PartnerTransferMerchantDetail()
-  * 微信V3：新增 client.V3Withdraw()
-  * 微信V3：新增 client.V3WithdrawStatus()
-  * 微信V3：新增 client.V3WithdrawDownloadErrBill()
-    (10) 微信V3：修改 V3TransferDetailQuery() => V3TransferDetail()
-    (11) 微信V3：修改 V3TransferMerchantDetailQuery() => V3TransferMerchantDetail()
+    * 微信V3：配合微信文档修改，拆分服务商 批量转账 相关接口，接口如下：
+    * 微信V3：新增 client.V3PartnerTransfer()
+    * 微信V3：新增 client.V3PartnerTransferQuery()
+    * 微信V3：新增 client.V3PartnerTransferDetail()
+    * 微信V3：新增 client.V3PartnerTransferMerchantQuery()
+    * 微信V3：新增 client.V3PartnerTransferMerchantDetail()
+    * 微信V3：新增 client.V3Withdraw()
+    * 微信V3：新增 client.V3WithdrawStatus()
+    * 微信V3：新增 client.V3WithdrawDownloadErrBill()
+      (10) 微信V3：修改 V3TransferDetailQuery() => V3TransferDetail()
+      (11) 微信V3：修改 V3TransferMerchantDetailQuery() => V3TransferMerchantDetail()
 
 ## 版本号：Release 1.5.66
 
 * 修改记录：
-  * 微信V3：fix bug that `{"code":"PARAM_ERROR","message":"平台证书序列号Wechatpay-Serial错误"}`
+    * 微信V3：fix bug that `{"code":"PARAM_ERROR","message":"平台证书序列号Wechatpay-Serial错误"}`
 
 ## 版本号：Release 1.5.65
 
 * 修改记录：
-  * 微信V3：新增 client.V3EcommerceApply()，二级商户进件
-  * 微信V3：新增 client.V3EcommerceApplyStatus()，查询申请状态
-  * 微信V3：新增 client.V3GoldPlanManage()，点金计划管理
-  * 微信V3：新增 client.V3GoldPlanBillManage()，商家小票管理
-  * 微信V3：新增 client.V3GoldPlanFilterManage()，同业过滤标签管理
-  * 微信V3：新增 client.V3GoldPlanOpenAdShow()，开通广告展示
-  * 微信V3：新增 client.V3GoldPlanCloseAdShow()，关闭广告展示
-  * 微信V3：公有化 wechat.GetReleaseSign()、wechat.GetSandBoxSign() 方法
-  * 微信V3：修改 client.V3PartnerCloseOrder() 入参参数
-    (10) GoPay：一些小修改优化
+    * 微信V3：新增 client.V3EcommerceApply()，二级商户进件
+    * 微信V3：新增 client.V3EcommerceApplyStatus()，查询申请状态
+    * 微信V3：新增 client.V3GoldPlanManage()，点金计划管理
+    * 微信V3：新增 client.V3GoldPlanBillManage()，商家小票管理
+    * 微信V3：新增 client.V3GoldPlanFilterManage()，同业过滤标签管理
+    * 微信V3：新增 client.V3GoldPlanOpenAdShow()，开通广告展示
+    * 微信V3：新增 client.V3GoldPlanCloseAdShow()，关闭广告展示
+    * 微信V3：公有化 wechat.GetReleaseSign()、wechat.GetSandBoxSign() 方法
+    * 微信V3：修改 client.V3PartnerCloseOrder() 入参参数
+      (10) GoPay：一些小修改优化
 
 ## 版本号：Release 1.5.64
 
 * 修改记录：
-  * xhttp：恢复 xhttp
+    * xhttp：恢复 xhttp
 
 ## 版本号：Release 1.5.63
 
 * 修改记录：
-  * GoPay：部分代码优化
-  * xhttp：xhttp client 优化，支持自定义client，默认还是使用标准 http.Client
+    * GoPay：部分代码优化
+    * xhttp：xhttp client 优化，支持自定义client，默认还是使用标准 http.Client
 
 ## 版本号：Release 1.5.62
 
 * 修改记录：
-  * 微信V3：client 内 WxSerialNo、ApiV3Key 公有化
-  * 微信V3：client 提供新方法 client.WxPublicKey() 直接获取 微信平台公钥
-  * 微信V3：wechat 提供新方法 wechat.V3VerifySignByPK()，不再推荐使用 wechat.V3VerifySign()
-  * 微信V3：V3NotifyReq 提供新方法 notify.VerifySignByPK()，不再推荐使用 notify.VerifySign()
-  * 微信V3：整理微信v3说明文档
+    * 微信V3：client 内 WxSerialNo、ApiV3Key 公有化
+    * 微信V3：client 提供新方法 client.WxPublicKey() 直接获取 微信平台公钥
+    * 微信V3：wechat 提供新方法 wechat.V3VerifySignByPK()，不再推荐使用 wechat.V3VerifySign()
+    * 微信V3：V3NotifyReq 提供新方法 notify.VerifySignByPK()，不再推荐使用 notify.VerifySign()
+    * 微信V3：整理微信v3说明文档
 
 ## 版本号：Release 1.5.61
 
 * 修改记录：
-  * gopay：更新 xhttp pkg, 方法全部增加 context 传递
+    * gopay：更新 xhttp pkg, 方法全部增加 context 传递
 
 ## 版本号：Release 1.5.60
 
 * 修改记录：
-  * 微信V3：不再推荐使用 client.SetPlatformCert() 方法
-  * 微信V3：新增 client.GetAndSelectNewestCert() 方法
-  * 微信V3：重构 client.AutoVerifySign() 方法
-  * QQ：新增 qq.GetAccessToken() 方法
-  * QQ：新增 qq.GetOpenId() 方法
-  * QQ：新增 qq.GetUserInfo() 方法
+    * 微信V3：不再推荐使用 client.SetPlatformCert() 方法
+    * 微信V3：新增 client.GetAndSelectNewestCert() 方法
+    * 微信V3：重构 client.AutoVerifySign() 方法
+    * QQ：新增 qq.GetAccessToken() 方法
+    * QQ：新增 qq.GetOpenId() 方法
+    * QQ：新增 qq.GetUserInfo() 方法
 
 ## 版本号：Release 1.5.59
 
 * 修改记录：
-  * 微信V3：证书获取方法返回结构体，去除 SignInfo 字段
-  * gopay：BodyMap，EncodeURLParams 方法稍作调整
-  * PayPal：PayPal支付能力接入（订单、支付）
+    * 微信V3：证书获取方法返回结构体，去除 SignInfo 字段
+    * gopay：BodyMap，EncodeURLParams 方法稍作调整
+    * PayPal：PayPal支付能力接入（订单、支付）
 
 ## 版本号：Release 1.5.58
 
 * 修改记录：
-  * 微信V3：新增 client.V3FavorMediaUploadImage() 图片上传(营销专用)
-  * 微信V3：新增 client.V3EcommerceIncomeRecord() 特约商户银行来账查询
-  * 微信V3：新增 client.V3EcommerceBalance() 查询特约商户账户实时余额
-  * 微信V3：新增 client.V3BusiFavorSend() 发放消费卡
-  * 微信V3：新增 client.V3PartnershipsBuild() 建立合作关系
-  * 微信V3：新增 client.V3PartnershipsTerminate() 终止合作关系
-  * 微信V3：新增 client.V3PartnershipsList() 查询合作关系列表
-  * 微信V3：修改 client.V3PartnerQueryOrder() 入参参数调整
-  * 微信V3：修改 client.V3BillLevel2FundFlowBill() => client.V3BillEcommerceFundFlowBill() 申请特约商户资金账单
-    (10) 支付宝：按照支付宝更新后的文档，修改大量接口返回参数结构体字段
+    * 微信V3：新增 client.V3FavorMediaUploadImage() 图片上传(营销专用)
+    * 微信V3：新增 client.V3EcommerceIncomeRecord() 特约商户银行来账查询
+    * 微信V3：新增 client.V3EcommerceBalance() 查询特约商户账户实时余额
+    * 微信V3：新增 client.V3BusiFavorSend() 发放消费卡
+    * 微信V3：新增 client.V3PartnershipsBuild() 建立合作关系
+    * 微信V3：新增 client.V3PartnershipsTerminate() 终止合作关系
+    * 微信V3：新增 client.V3PartnershipsList() 查询合作关系列表
+    * 微信V3：修改 client.V3PartnerQueryOrder() 入参参数调整
+    * 微信V3：修改 client.V3BillLevel2FundFlowBill() => client.V3BillEcommerceFundFlowBill() 申请特约商户资金账单
+      (10) 支付宝：按照支付宝更新后的文档，修改大量接口返回参数结构体字段
 
 ## 版本号：Release 1.5.57
 
 * 修改记录：
-  * 微信V3：修复一些已知问题
-  * 支付宝：一些细小的修复，部分参数类型更正
+    * 微信V3：修复一些已知问题
+    * 支付宝：一些细小的修复，部分参数类型更正
 
 ## 版本号：Release 1.5.56
 
 * 修改记录：
-  * 微信V3：修改 client.V3ProfitShareReturnResult() 接口入参，适配服务商模式
-  * 微信V3：部分接口参数需要加密，修复 V3EncryptText() 和 V3DecryptText() 方法
-  * 支付宝：修改 alipay.NewClient()，增加error返回值，去除Client内部分字段
-  * Apple：新增apple pay的 apple.VerifyReceipt() 校验收据API
-  * 优化代码中所有有关证书的解析操作
+    * 微信V3：修改 client.V3ProfitShareReturnResult() 接口入参，适配服务商模式
+    * 微信V3：部分接口参数需要加密，修复 V3EncryptText() 和 V3DecryptText() 方法
+    * 支付宝：修改 alipay.NewClient()，增加error返回值，去除Client内部分字段
+    * Apple：新增apple pay的 apple.VerifyReceipt() 校验收据API
+    * 优化代码中所有有关证书的解析操作
 
 ## 版本号：Release 1.5.55
 
 * 修改记录：
-  * 微信V3：wechat.NewClientV3()，去掉初始化参数 appid，所以方法中需要 appid 或sp_appid 的，需要自行传参
-  * 微信V3：新增 代金券 相关接口
-  * 微信V3：新增 商家券 相关接口
-  * 微信V2、V3：修复部分接口发现的Bug
+    * 微信V3：wechat.NewClientV3()，去掉初始化参数 appid，所以方法中需要 appid 或sp_appid 的，需要自行传参
+    * 微信V3：新增 代金券 相关接口
+    * 微信V3：新增 商家券 相关接口
+    * 微信V2、V3：修复部分接口发现的Bug
 
 ## 版本号：Release 1.5.54
 
 * 修改记录：
-  * 微信V3：新增微信支付分回调参数解密方法 notifyReq.DecryptScoreCipherText()
-  * 微信V3：新增分账接口 client.V3ProfitShareMerchantConfigs()
-  * Readme：更新Readme
+    * 微信V3：新增微信支付分回调参数解密方法 notifyReq.DecryptScoreCipherText()
+    * 微信V3：新增分账接口 client.V3ProfitShareMerchantConfigs()
+    * Readme：更新Readme
 
 ## 版本号：Release 1.5.53
 
 * 修改记录：
-  * 支付宝：补充接口
-  * 微信V3：修改支付分相关接口的返回参数字段， out_trade_no 为 out_order_no
+    * 支付宝：补充接口
+    * 微信V3：修改支付分相关接口的返回参数字段， out_trade_no 为 out_order_no
 
 ## 版本号：Release 1.5.52
 
 * 修改记录：
-  * 支付宝：补充 支付API 相关接口
-  * pkg：xhttp.Client 的 Transport 默认配置：Proxy: http.ProxyFromEnvironment
+    * 支付宝：补充 支付API 相关接口
+    * pkg：xhttp.Client 的 Transport 默认配置：Proxy: http.ProxyFromEnvironment
 
 ## 版本号：Release 1.5.51
 
 * 修改记录：
-  * 微信：新增 特约商户进件（服务商平台） 相关接口
-  * 支付宝：补充完整 芝麻分 相关接口
-  * 支付宝：补充 会员API 相关接口
+    * 微信：新增 特约商户进件（服务商平台） 相关接口
+    * 支付宝：补充完整 芝麻分 相关接口
+    * 支付宝：补充 会员API 相关接口
 
 ## 版本号：Release 1.5.50
 
 * 修改记录：
-  * 支付宝：新增 芝麻分 相关接口
-  * 支付宝：当判断 Response 中 code!="10000" 时，不再返回nil，而是返回 aliRsp 结果
+    * 支付宝：新增 芝麻分 相关接口
+    * 支付宝：当判断 Response 中 code!="10000" 时，不再返回nil，而是返回 aliRsp 结果
 
 ## 版本号：Release 1.5.49
 
 * 修改记录：
-  * 微信V3：新增 wechat.GetPlatformCerts()，无需初始化V3client，直接获取微信平台证书和序列号等信息
-  * gopay：更新 go mod version
-  * 微信V2：新增 client.CustomsDeclareOrder()，订单附加信息提交（正式环境）
-  * 微信V2：新增 client.CustomsDeclareQuery()，订单附加信息查询（正式环境）
-  * 微信V2：新增 client.CustomsReDeclareOrder()，订单附加信息重推（正式环境）
-  * 支付宝：新增 client.TradeCustomsDeclare()，统一收单报关接口（正式环境）
-  * 支付宝：新增 client.AcquireCustoms()，报关接口（正式环境），未经测试
-  * 支付宝：新增 client.AcquireCustomsQuery()，报关查询接口（正式环境），未经测试
+    * 微信V3：新增 wechat.GetPlatformCerts()，无需初始化V3client，直接获取微信平台证书和序列号等信息
+    * gopay：更新 go mod version
+    * 微信V2：新增 client.CustomsDeclareOrder()，订单附加信息提交（正式环境）
+    * 微信V2：新增 client.CustomsDeclareQuery()，订单附加信息查询（正式环境）
+    * 微信V2：新增 client.CustomsReDeclareOrder()，订单附加信息重推（正式环境）
+    * 支付宝：新增 client.TradeCustomsDeclare()，统一收单报关接口（正式环境）
+    * 支付宝：新增 client.AcquireCustoms()，报关接口（正式环境），未经测试
+    * 支付宝：新增 client.AcquireCustomsQuery()，报关查询接口（正式环境），未经测试
 
 ## 版本号：Release 1.5.48
 
 * 修改记录：
-  * 微信V3：修复 平台证书序列号Wechatpay-Serial错误 问题
-  * 微信V3：新增 client.SetPlatformCert()，设置 微信支付平台证书 和 证书序列号 方法
-  * 微信V3：新增 client.V3EncryptText()，请求参数 敏感信息 加密方法
-  * 微信V3：新增 client.V3DecryptText()，返回参数 敏感信息 解密方法
-  * 微信V3：修改 client.AutoVerifySign() 方法无需传参，但需要提前调用 client.SetPlatformCert() 设置 微信支付平台证书 和
-    证书序列号
+    * 微信V3：修复 平台证书序列号Wechatpay-Serial错误 问题
+    * 微信V3：新增 client.SetPlatformCert()，设置 微信支付平台证书 和 证书序列号 方法
+    * 微信V3：新增 client.V3EncryptText()，请求参数 敏感信息 加密方法
+    * 微信V3：新增 client.V3DecryptText()，返回参数 敏感信息 解密方法
+    * 微信V3：修改 client.AutoVerifySign() 方法无需传参，但需要提前调用 client.SetPlatformCert() 设置 微信支付平台证书 和
+      证书序列号
 
 ## 版本号：Release 1.5.47
 
 * 修改记录：
-  * 微信V3：新增 转账相关 相关接口
-  * 微信V3：新增 账户余额查询 相关接口
-  * 微信V3：新增 来账识别 相关接口
+    * 微信V3：新增 转账相关 相关接口
+    * 微信V3：新增 账户余额查询 相关接口
+    * 微信V3：新增 来账识别 相关接口
 
 ## 版本号：Release 1.5.46
 
 * 修改记录：
-  * 微信V3：新增敏感信息加解密方法，wechat.V3EncryptText() 加密数据，wechat.V3DecryptText() 解密数据
-  * 微信V3：新增 微信先享卡 相关接口
-  * 微信V3：新增 支付即服务 相关接口
-  * 微信V3：新增 智慧商圈 相关接口
+    * 微信V3：新增敏感信息加解密方法，wechat.V3EncryptText() 加密数据，wechat.V3DecryptText() 解密数据
+    * 微信V3：新增 微信先享卡 相关接口
+    * 微信V3：新增 支付即服务 相关接口
+    * 微信V3：新增 智慧商圈 相关接口
 
 ## 版本号：Release 1.5.45
 
 * 修改记录：
-  * 支付宝：优化现有代码，修复公钥证书模式下，同步验签失败的问题
-  * 支付宝：新增 client.AutoVerifySign()，自动同步验签设置（公钥证书模式）
-  * 支付宝：新增 client.PublicCertDownload()，应用支付宝公钥证书下载
-  * 支付宝：新增 client.FundTransPayeeBindQuery()，资金收款账号绑定关系查询
-  * 支付宝：新增 client.OpenAppQrcodeCreate()，小程序生成推广二维码接口
-  * 支付宝：新增 client.UserAgreementPageSign()，支付宝个人协议页面签约接口
-  * 支付宝：新增 client.UserAgreementPageUnSign()，支付宝个人代扣协议解约接口
-  * 支付宝：新增 client.UserAgreementQuery()，支付宝个人代扣协议查询接口
-  * 支付宝：新增 client.TradeOrderInfoSync()，支付宝订单信息同步接口
-    (10) 支付宝：新增 client.TradeAdvanceConsult()，订单咨询服务
+    * 支付宝：优化现有代码，修复公钥证书模式下，同步验签失败的问题
+    * 支付宝：新增 client.AutoVerifySign()，自动同步验签设置（公钥证书模式）
+    * 支付宝：新增 client.PublicCertDownload()，应用支付宝公钥证书下载
+    * 支付宝：新增 client.FundTransPayeeBindQuery()，资金收款账号绑定关系查询
+    * 支付宝：新增 client.OpenAppQrcodeCreate()，小程序生成推广二维码接口
+    * 支付宝：新增 client.UserAgreementPageSign()，支付宝个人协议页面签约接口
+    * 支付宝：新增 client.UserAgreementPageUnSign()，支付宝个人代扣协议解约接口
+    * 支付宝：新增 client.UserAgreementQuery()，支付宝个人代扣协议查询接口
+    * 支付宝：新增 client.TradeOrderInfoSync()，支付宝订单信息同步接口
+      (10) 支付宝：新增 client.TradeAdvanceConsult()，订单咨询服务
 
 ## 版本号：Release 1.5.44
 
 * 修改记录：
-  * 微信V3：新增 图片上传 接口
-  * 微信V3：新增 视频上传 接口
-  * 微信V3：修复消费者投诉接口中的图片上传失败问题
+    * 微信V3：新增 图片上传 接口
+    * 微信V3：新增 视频上传 接口
+    * 微信V3：修复消费者投诉接口中的图片上传失败问题
 
 ## 版本号：Release 1.5.42
 
 * 修改记录：
-  * 迁移新仓库 https://github.com/go-pay/gopay
+    * 迁移新仓库 https://github.com/go-pay/gopay
 
 ## 版本号：Release 1.5.41
 
 * 修改记录：
-  * 微信V3：新增 消费者投诉2.0 相关接口
-  * 微信V3：新增 分账 相关接口
+    * 微信V3：新增 消费者投诉2.0 相关接口
+    * 微信V3：新增 分账 相关接口
 
 ## 版本号：Release 1.5.40
 
 * 修改记录：
-  * 微信V3：新增微信支付分（免确认模式）相关接口
-  * 微信V3：新增微信支付分（免确认预授权模式）相关接口
+    * 微信V3：新增微信支付分（免确认模式）相关接口
+    * 微信V3：新增微信支付分（免确认预授权模式）相关接口
 
 ## 版本号：Release 1.5.39
 
 * 修改记录：
-  * 微信V3：新增微信支付分（公共API）相关接口
+    * 微信V3：新增微信支付分（公共API）相关接口
 
 ## 版本号：Release 1.5.38
 
 * 修改记录：
-  * 微信：去掉所以微信 client 方法中需要传证书的参数，请统一在初始化client时，添加证书
-  * 微信：使用方法请参考 wechat/client_test.go 下的初始化，以及各个方法使用
+    * 微信：去掉所以微信 client 方法中需要传证书的参数，请统一在初始化client时，添加证书
+    * 微信：使用方法请参考 wechat/client_test.go 下的初始化，以及各个方法使用
 
 ## 版本号：Release 1.5.37
 
 * 修改记录：
-  * 支付宝：修改 client.FundAuthOrderAppFreeze() 接口返回参数
-  * 支付宝：新增 client.GetRequestSignParam()，获取已签名的完整请求参数
-  * 微信V3：增加 client.GetPlatformCerts()，获取微信平台证书公钥，增加注释说明
-  * 支付宝：拆分 _test.go 文件
+    * 支付宝：修改 client.FundAuthOrderAppFreeze() 接口返回参数
+    * 支付宝：新增 client.GetRequestSignParam()，获取已签名的完整请求参数
+    * 微信V3：增加 client.GetPlatformCerts()，获取微信平台证书公钥，增加注释说明
+    * 支付宝：拆分 _test.go 文件
 
 ## 版本号：Release 1.5.36
 
 * 修改记录：
-  * 支付宝：新增 资金API 类别 接口实现
-  * 微信V3：修复银行转账接口，银行卡号和收款人的 RSA 加密bug
-  * 一些其他小修复调整
+    * 支付宝：新增 资金API 类别 接口实现
+    * 微信V3：修复银行转账接口，银行卡号和收款人的 RSA 加密bug
+    * 一些其他小修复调整
 
 ## 版本号：Release 1.5.35
 
 * 修改记录：
-  * 微信V3：修复 普通支付回调通知 解密后的结构体问题
-  * 微信V3：新增 合单支付回调通知
-  * 微信V3：修复 退款回调通知 解密后的结构体问题
+    * 微信V3：修复 普通支付回调通知 解密后的结构体问题
+    * 微信V3：新增 合单支付回调通知
+    * 微信V3：修复 退款回调通知 解密后的结构体问题
 
 ## 版本号：Release 1.5.34
 
 * 修改记录：
-  * 微信V3：修复 client.GetPlatformCerts() 的返回值 code 问题
-  * ReadMe：补充 README.md 说明
-  * 微信V3：修复 PaySignOfApp() 签名出错的问题
-  * 微信V2：部分文件调整
+    * 微信V3：修复 client.GetPlatformCerts() 的返回值 code 问题
+    * ReadMe：补充 README.md 说明
+    * 微信V3：修复 PaySignOfApp() 签名出错的问题
+    * 微信V2：部分文件调整
 
 ## 版本号：Release 1.5.32
 
 * 修改记录：
-  * xhttp：Fix bug about Transport
+    * xhttp：Fix bug about Transport
 
 ## 版本号：Release 1.5.31
 
 * 修改记录：
-  * 微信：新增服务商支付接口
+    * 微信：新增服务商支付接口
 
 ## 版本号：Release 1.5.30
 
 * 修改记录：
-  * BodyMap：恢复 bm.Get() 方法获取的是string类型，增加 bm.GetInterface()
-  * 微信：新增V3版本退款查询接口
+    * BodyMap：恢复 bm.Get() 方法获取的是string类型，增加 bm.GetInterface()
+    * 微信：新增V3版本退款查询接口
 
 ## 版本号：Release 1.5.29
 
 发布时间：2021/02/27 22:49
 
 * 修改记录：
-  * 支付宝：新增 client.PostAliPayAPISelfV2()，比非V2版本更灵活化，具体参考 client_test.go 内的
-    TestClient_PostAliPayAPISelfV2() 方法
-  * BodyMap：新增 bm.SetFormFile() 的部分方法，修改 bm.Get() 方法，新增bm.GetString() 方法
-  * xHttp：更新 httpClient， httpClient.Type() 支持 TypeMultipartFormData 类型
-  * go mod 版本改为 1.14
+    * 支付宝：新增 client.PostAliPayAPISelfV2()，比非V2版本更灵活化，具体参考 client_test.go 内的
+      TestClient_PostAliPayAPISelfV2() 方法
+    * BodyMap：新增 bm.SetFormFile() 的部分方法，修改 bm.Get() 方法，新增bm.GetString() 方法
+    * xHttp：更新 httpClient， httpClient.Type() 支持 TypeMultipartFormData 类型
+    * go mod 版本改为 1.14
 
 ## 版本号：Release 1.5.28
 
 发布时间：2021/02/19 18:48
 
 * 修改记录：
-  * QQ：新增 client.AddCertFileContent()，解决无证书文件，只有证书内容的问题
-  * 支付宝：新增 alipay.VerifySyncSignWithCert()，同步证书验签
-  * 支付宝：新增 client.SetCertSnByContent()，通过应用公钥证书内容设置 app_cert_sn、alipay_root_cert_sn、alipay_cert_sn
-  * 支付宝：删除废弃接口 client.FundTransToaccountTransfer()
-  * fix BodyMap 的部分方法
+    * QQ：新增 client.AddCertFileContent()，解决无证书文件，只有证书内容的问题
+    * 支付宝：新增 alipay.VerifySyncSignWithCert()，同步证书验签
+    * 支付宝：新增 client.SetCertSnByContent()，通过应用公钥证书内容设置 app_cert_sn、alipay_root_cert_sn、alipay_cert_sn
+    * 支付宝：删除废弃接口 client.FundTransToaccountTransfer()
+    * fix BodyMap 的部分方法
 
 ## 版本号：Release 1.5.27
 
 发布时间：2021/02/03 18:50
 
 * 修改记录：
-  * GoPay：去掉对 gotil 的强依赖
+    * GoPay：去掉对 gotil 的强依赖
 
 ## 版本号：Release 1.5.26
 
 发布时间：2021/01/29 19:38
 
 * 修改记录：
-  * 微信：重新整理文件分级，商户分账模块增加test方法说明
-  * BodyMap: 去除 GetArrayBodyMap()、GetBodyMap() 方法
+    * 微信：重新整理文件分级，商户分账模块增加test方法说明
+    * BodyMap: 去除 GetArrayBodyMap()、GetBodyMap() 方法
 
 ## 版本号：Release 1.5.25
 
 发布时间：2020/12/31 18:38
 
 * 修改记录：
-  * 微信：v3 基础支付接口完成，使用请参考：gopay/wechat/v3/client_test.go
+    * 微信：v3 基础支付接口完成，使用请参考：gopay/wechat/v3/client_test.go
 
 ## 版本号：Release 1.5.24
 
 发布时间：2020/12/21 18:58
 
 * 修改记录：
-  * 微信：证书支持二选一，只传 apiclient_cert.pem 和 apiclient_key.pem 或者只传 apiclient_cert.p12
+    * 微信：证书支持二选一，只传 apiclient_cert.pem 和 apiclient_key.pem 或者只传 apiclient_cert.p12
 
 ## 版本号：Release 1.5.23
 
 发布时间：2020/12/15 17:58
 
 * 修改记录：
-  * 微信：新增 client.AddCertFileContent()，解决无证书文件，只有证书内容的问题
+    * 微信：新增 client.AddCertFileContent()，解决无证书文件，只有证书内容的问题
 
 ## 版本号：Release 1.5.22
 
 发布时间：2020/12/04 02:58
 
 * 修改记录：
-  * 更新 gotil，修复xlog导致 go 1.14 以下版本报bug问题
-  * 采纳 WenyXu 的意见，优化BodyMap的用法
+    * 更新 gotil，修复xlog导致 go 1.14 以下版本报bug问题
+    * 采纳 WenyXu 的意见，优化BodyMap的用法
 
 ## 版本号：Release 1.5.20
 
 发布时间：2020/09/30 23:58
 
 * 修改记录：
-  * 微信：client 添加 DebugSwitch 开关，默认关闭，不输出 请求参数和返回参数，通过 client.DebugSwitch = gopay.DebugOn 打开
-  * 支付宝：client 添加 DebugSwitch 开关，默认关闭，不输出 请求参数和返回参数，通过 client.DebugSwitch = gopay.DebugOn 打开
-  * QQ：client 添加 DebugSwitch 开关，默认关闭，不输出 请求参数和返回参数，通过 client.DebugSwitch = gopay.DebugOn 打开
-  * 更新 Gotil
+    * 微信：client 添加 DebugSwitch 开关，默认关闭，不输出 请求参数和返回参数，通过 client.DebugSwitch = gopay.DebugOn 打开
+    * 支付宝：client 添加 DebugSwitch 开关，默认关闭，不输出 请求参数和返回参数，通过 client.DebugSwitch = gopay.DebugOn 打开
+    * QQ：client 添加 DebugSwitch 开关，默认关闭，不输出 请求参数和返回参数，通过 client.DebugSwitch = gopay.DebugOn 打开
+    * 更新 Gotil
 
 ## 版本号：Release 1.5.19
 
 发布时间：2020/09/20 23:58
 
 * 修改记录：
-  * 微信：修复 client.ProfitSharingQuery() 接口的Bug，https://github.com/iGoogle-ink/gopay/issues/68
-  * 微信：优化 client.doProdPost()
-  * 支付宝：优化 client.doAliPay()
-  * 微信：项目文件区分改动，开放平台接口和微信公众号区分
-  * 微信：替换 wechat.GetAppLoginAccessToken() = > wechat.GetOauth2AccessToken()
-  * 微信：替换 wechat.RefreshAppLoginAccessToken() = > wechat.RefreshOauth2AccessToken()
-  * 微信：替换 wechat.GetUserInfoOpen() = > wechat.GetOauth2UserInfo()
-  * 微信：替换 wechat.GetUserInfo() = > wechat.GetPublicUserInfo()
-  * 微信：新增 wechat.CheckOauth2AccessToken() 检验授权凭证（access_token）是否有效
-    (10) 微信：新增 wechat.GetPublicUserInfoBatch() 批量获取用户基本信息（微信公众号）
-    (11) 微信：新增 client.SendCashRed() 发放现金红包
-    (12) 微信：新增 client.SendGroupCashRed() 发放现金裂变红包
-    (13) 微信：新增 client.SendAppletRed() 发放小程序红包
-    (14) 微信：新增 client.QueryRedRecord() 查询红包记录
-    (15) QQ：新增 client.SendCashRed() 创建现金红包，（未经测试，有条件的帮忙测一下吧，有问题提PR）
-    (16) QQ：新增 client.DownloadRedListFile() 对账单下载，（未经测试，有条件的帮忙测一下吧，有问题提PR）
-    (17) QQ：新增 client.QueryRedInfo() 查询红包详情，（未经测试，有条件的帮忙测一下吧，有问题提PR）
+    * 微信：修复 client.ProfitSharingQuery() 接口的Bug，https://github.com/iGoogle-ink/gopay/issues/68
+    * 微信：优化 client.doProdPost()
+    * 支付宝：优化 client.doAliPay()
+    * 微信：项目文件区分改动，开放平台接口和微信公众号区分
+    * 微信：替换 wechat.GetAppLoginAccessToken() = > wechat.GetOauth2AccessToken()
+    * 微信：替换 wechat.RefreshAppLoginAccessToken() = > wechat.RefreshOauth2AccessToken()
+    * 微信：替换 wechat.GetUserInfoOpen() = > wechat.GetOauth2UserInfo()
+    * 微信：替换 wechat.GetUserInfo() = > wechat.GetPublicUserInfo()
+    * 微信：新增 wechat.CheckOauth2AccessToken() 检验授权凭证（access_token）是否有效
+      (10) 微信：新增 wechat.GetPublicUserInfoBatch() 批量获取用户基本信息（微信公众号）
+      (11) 微信：新增 client.SendCashRed() 发放现金红包
+      (12) 微信：新增 client.SendGroupCashRed() 发放现金裂变红包
+      (13) 微信：新增 client.SendAppletRed() 发放小程序红包
+      (14) 微信：新增 client.QueryRedRecord() 查询红包记录
+      (15) QQ：新增 client.SendCashRed() 创建现金红包，（未经测试，有条件的帮忙测一下吧，有问题提PR）
+      (16) QQ：新增 client.DownloadRedListFile() 对账单下载，（未经测试，有条件的帮忙测一下吧，有问题提PR）
+      (17) QQ：新增 client.QueryRedInfo() 查询红包详情，（未经测试，有条件的帮忙测一下吧，有问题提PR）
 
 ## 版本号：Release 1.5.18
 
 发布时间：2020/08/29 18:30
 
 * 修改记录：
-  * 微信：修复 client.AddCertFilePath() 无效的Bug
-  * QQ：修复 client.AddCertFilePath() 无效的Bug
-  * Gotil：升级 gotil 到 v1.0.7-beta2 版本
-  * 支付宝：OpenAuthTokenAppResponse 结构体中 ExpiresIn、ReExpiresIn
-    字段改为int64（有用户反馈返回的是int类型，但文档写的是string），如果此处有问题，请立马联系改回去。
+    * 微信：修复 client.AddCertFilePath() 无效的Bug
+    * QQ：修复 client.AddCertFilePath() 无效的Bug
+    * Gotil：升级 gotil 到 v1.0.7-beta2 版本
+    * 支付宝：OpenAuthTokenAppResponse 结构体中 ExpiresIn、ReExpiresIn
+      字段改为int64（有用户反馈返回的是int类型，但文档写的是string），如果此处有问题，请立马联系改回去。
 
 ## 版本号：Release 1.5.17
 
 发布时间：2020/08/23 15:30
 
 * 修改记录：
-  * 微信：Response model 增加字段
-  * ReadMe：修改部分遗留未更改的文档内容
-  * 支付宝：添加证书由只支持证书路径，改为支持证书路径或者这书Byte数组
-  * 支付宝：修复SystemOauthToken()方法未添加 AppCertSN 和 AliPayRootCertSN 的问题
+    * 微信：Response model 增加字段
+    * ReadMe：修改部分遗留未更改的文档内容
+    * 支付宝：添加证书由只支持证书路径，改为支持证书路径或者这书Byte数组
+    * 支付宝：修复SystemOauthToken()方法未添加 AppCertSN 和 AliPayRootCertSN 的问题
 
 ## 版本号：Release 1.5.16
 
 发布时间：2020/07/29 18:30
 
 * 修改记录：
-  * 微信：新增公共方法：wechat.GetUserInfoOpen()，微信开放平台：获取用户个人信息(UnionID机制)
-  * Gotil：升级 gotil 到 v1.0.4 版本
-  * 微信：新增ReadMe说明，微信支付下单等操作可用沙箱环境测试是否成功，但真正支付时，请使用正式环境，isProd = true，不然会报错
+    * 微信：新增公共方法：wechat.GetUserInfoOpen()，微信开放平台：获取用户个人信息(UnionID机制)
+    * Gotil：升级 gotil 到 v1.0.4 版本
+    * 微信：新增ReadMe说明，微信支付下单等操作可用沙箱环境测试是否成功，但真正支付时，请使用正式环境，isProd = true，不然会报错
 
 ## 版本号：Release 1.5.15
 
 发布时间：2020/07/09 18:30
 
 * 修改记录：
-  * 微信：新增client方法：client.ProfitSharing()，请求单次分账
-  * 微信：新增client方法：client.MultiProfitSharing()，请求多次分账
-  * 微信：新增client方法：client.ProfitSharingQuery()，查询分账结果
-  * 微信：新增client方法：client.ProfitSharingAddReceiver()，添加分账接收方
-  * 微信：新增client方法：client.ProfitSharingRemoveReceiver()，删除分账接收方
-  * 微信：新增client方法：client.ProfitSharingFinish()，完结分账
-  * 微信：新增client方法：client.ProfitSharingReturn()，分账回退
-  * 微信：新增client方法：client.ProfitSharingReturnQuery()，分账回退结果查询
-  * 微信：新增client方法：client.PayBank()，企业付款到银行卡API
-    (10) 微信：新增client方法：client.QueryBank()，查询企业付款到银行卡API
-    (11) 微信：新增client方法：client.GetRSAPublicKey()，获取RSA加密公钥API
-    (12) 微信：修改client方法名：client.PostRequest() -> client.PostWeChatAPISelf()
-    (13) QQ：修改client方法名：client.PostRequest() -> client.PostQQAPISelf()
-    (14) 说明：方法未经严格测试，还请开发者在开始使用时确认是否正常使用，有问题请提 issue
+    * 微信：新增client方法：client.ProfitSharing()，请求单次分账
+    * 微信：新增client方法：client.MultiProfitSharing()，请求多次分账
+    * 微信：新增client方法：client.ProfitSharingQuery()，查询分账结果
+    * 微信：新增client方法：client.ProfitSharingAddReceiver()，添加分账接收方
+    * 微信：新增client方法：client.ProfitSharingRemoveReceiver()，删除分账接收方
+    * 微信：新增client方法：client.ProfitSharingFinish()，完结分账
+    * 微信：新增client方法：client.ProfitSharingReturn()，分账回退
+    * 微信：新增client方法：client.ProfitSharingReturnQuery()，分账回退结果查询
+    * 微信：新增client方法：client.PayBank()，企业付款到银行卡API
+      (10) 微信：新增client方法：client.QueryBank()，查询企业付款到银行卡API
+      (11) 微信：新增client方法：client.GetRSAPublicKey()，获取RSA加密公钥API
+      (12) 微信：修改client方法名：client.PostRequest() -> client.PostWeChatAPISelf()
+      (13) QQ：修改client方法名：client.PostRequest() -> client.PostQQAPISelf()
+      (14) 说明：方法未经严格测试，还请开发者在开始使用时确认是否正常使用，有问题请提 issue
 
 ## 版本号：Release 1.5.14
 
 发布时间：2020/06/27 3:30
 
 * 修改记录：
-  * 引入 github.com/iGoogle-ink/gotil 包
-  * 替换 log 输出样式
-  * 支付宝：新增client方法：client.PostAliPayAPISelf()，支付宝接口自行实现方法
+    * 引入 github.com/iGoogle-ink/gotil 包
+    * 替换 log 输出样式
+    * 支付宝：新增client方法：client.PostAliPayAPISelf()，支付宝接口自行实现方法
 
 ## 版本号：Release 1.5.12
 
 发布时间：2020/05/20 02:10
 
 * 修改记录：
-  * http_client：增加默认请求的超时时间 60s，增加 SetTimeout() 方法，可自定义超时时间
-  * 微信：修改 申请退款、退款查询、订单查询 接口的返回结构体，增加带下标的部分字段
-  * 微信：增加 申请退款、退款查询、订单查询 接口的返回值，新增了 resBm BodyMap 类型，方便接收结构体中未定义到的下标字段
-  * 微信：新增client方法：client.GetTransferInfo()，查询企业退款，此方法实际暂未测试，请自行测试，有问题提issue
+    * http_client：增加默认请求的超时时间 60s，增加 SetTimeout() 方法，可自定义超时时间
+    * 微信：修改 申请退款、退款查询、订单查询 接口的返回结构体，增加带下标的部分字段
+    * 微信：增加 申请退款、退款查询、订单查询 接口的返回值，新增了 resBm BodyMap 类型，方便接收结构体中未定义到的下标字段
+    * 微信：新增client方法：client.GetTransferInfo()，查询企业退款，此方法实际暂未测试，请自行测试，有问题提issue
 
 ## 版本号：Release 1.5.11
 
 发布时间：2020/05/13 17:15
 
 * 修改记录：
-  * 支付宝：修复rsp解析出错的问题 client.SystemOauthToken()
-  * 微信：修改部分公共方法Rsp结构体参数问题，同步微信文档
+    * 支付宝：修复rsp解析出错的问题 client.SystemOauthToken()
+    * 微信：修改部分公共方法Rsp结构体参数问题，同步微信文档
 
 ## 版本号：Release 1.5.10
 
 发布时间：2020/05/06 20:15
 
 * 修改记录：
-  * 微信：修改部分公共方法返回值结构体字段类型
-  * drone fix
+    * 微信：修改部分公共方法返回值结构体字段类型
+    * drone fix
 
 ## 版本号：Release 1.5.9
 
 发布时间：2020/04/25 15:32
 
 * 修改记录：
-  * 支付宝：异步验签，推荐使用 alipay.ParseNotifyToBodyMap()，解析参数后参数在Verify验签时，推荐传入参数BodyMap bm。
-  * 支付宝：修改公共方法：alipay.ParseNotifyResultToBodyMap() 为 alipay.ParseNotifyToBodyMap()
-  * 支付宝：修改公共方法：alipay.ParseNotifyResultByURLValues() 为 alipay.ParseNotifyByURLValues()
-  * 支付宝：废弃公共方法：alipay.ParseNotifyResult()，因为异步通知有参数因为支付接口不同，返回的字段不同，无法使用结构体全部定义好
-  * 支付宝：调整了部分接口的文档地址
-  * 微信：修改公共方法：wechat.ParseNotifyResultToBodyMap() 为 wechat.ParseNotifyToBodyMap()
-  * 微信：修改公共方法：wechat.ParseNotifyResult() 为 wechat.ParseNotify()
-  * 微信：修改公告方法：wechat.ParseRefundNotifyResult() 为 wechat.ParseRefundNotify()
+    * 支付宝：异步验签，推荐使用 alipay.ParseNotifyToBodyMap()，解析参数后参数在Verify验签时，推荐传入参数BodyMap bm。
+    * 支付宝：修改公共方法：alipay.ParseNotifyResultToBodyMap() 为 alipay.ParseNotifyToBodyMap()
+    * 支付宝：修改公共方法：alipay.ParseNotifyResultByURLValues() 为 alipay.ParseNotifyByURLValues()
+    * 支付宝：废弃公共方法：alipay.ParseNotifyResult()，因为异步通知有参数因为支付接口不同，返回的字段不同，无法使用结构体全部定义好
+    * 支付宝：调整了部分接口的文档地址
+    * 微信：修改公共方法：wechat.ParseNotifyResultToBodyMap() 为 wechat.ParseNotifyToBodyMap()
+    * 微信：修改公共方法：wechat.ParseNotifyResult() 为 wechat.ParseNotify()
+    * 微信：修改公告方法：wechat.ParseRefundNotifyResult() 为 wechat.ParseRefundNotify()
 
 ## 版本号：Release 1.5.8
 
 发布时间：2020/04/18 21:32
 
 * 修改记录：
-  * 微信：新增Client方法：client.PostRequest()，向微信发送Post请求，对于本库未提供的微信API，可自行实现，通过此方法发送请求
-  * 微信：微信同步返回结构体类型全部修改为string类型，验签出错的问题
-  * 微信：Client方法，需要传证书的接口方法，入参类型统一改为any,无需传证书地址时，由 "" 改为 nil
-  * QQ：同微信改动
-  * 支付宝：model结构体参数全部修改为string类型
+    * 微信：新增Client方法：client.PostRequest()，向微信发送Post请求，对于本库未提供的微信API，可自行实现，通过此方法发送请求
+    * 微信：微信同步返回结构体类型全部修改为string类型，验签出错的问题
+    * 微信：Client方法，需要传证书的接口方法，入参类型统一改为any,无需传证书地址时，由 "" 改为 nil
+    * QQ：同微信改动
+    * 支付宝：model结构体参数全部修改为string类型
 
 ## 版本号：Release 1.5.7
 
 发布时间：2020/03/25 20:32
 
 * 修改记录：
-  * 支付宝：修改 client.UserCertifyOpenQuery() 方法的返回值解析类型报错问题，官方文档类型实例有误
+    * 支付宝：修改 client.UserCertifyOpenQuery() 方法的返回值解析类型报错问题，官方文档类型实例有误
 
 ## 版本号：Release 1.5.6
 
 发布时间：2020/03/06 17:32
 
 * 修改记录：
-  * 支付宝：新增Client方法：client.SetPrivateKeyType()，设置 支付宝 私钥类型，alipay.PKCS1 或 alipay.PKCS8，默认 PKCS1。
-  * 支付宝：修改公共方法：alipay.GetRsaSign()，增加了私钥类型参数，并将私钥的格式化操作，移动到该方法内，传入的私钥无需事先格式化。
+    * 支付宝：新增Client方法：client.SetPrivateKeyType()，设置 支付宝 私钥类型，alipay.PKCS1 或 alipay.PKCS8，默认 PKCS1。
+    * 支付宝：修改公共方法：alipay.GetRsaSign()，增加了私钥类型参数，并将私钥的格式化操作，移动到该方法内，传入的私钥无需事先格式化。
 
 ## 版本号：Release 1.5.5
 
 发布时间：2020/03/05 18:32
 
 * 修改记录：
-  * 支付宝：新增Client方法：client.DataBillBalanceQuery()，支付宝商家账户当前余额查询。
-  * 支付宝：新增Client方法：client.DataBillDownloadUrlQuery()，查询对账单下载地址。
-  * 支付宝：开放公共方法：alipay.GetRsaSign()，获取支付宝参数签名（参数sign值）。
-  * 支付宝：开放公共方法：alipay.FormatURLParam()，格式化支付宝请求URL参数。
-  * 支付宝：新增公共方法：alipay.ParseNotifyResultByURLValues()，通过 url.Values 解析支付宝支付异步通知的参数到Struct。
+    * 支付宝：新增Client方法：client.DataBillBalanceQuery()，支付宝商家账户当前余额查询。
+    * 支付宝：新增Client方法：client.DataBillDownloadUrlQuery()，查询对账单下载地址。
+    * 支付宝：开放公共方法：alipay.GetRsaSign()，获取支付宝参数签名（参数sign值）。
+    * 支付宝：开放公共方法：alipay.FormatURLParam()，格式化支付宝请求URL参数。
+    * 支付宝：新增公共方法：alipay.ParseNotifyResultByURLValues()，通过 url.Values 解析支付宝支付异步通知的参数到Struct。
 
 ## 版本号：Release 1.5.4
 
 发布时间：2020/02/29 14:32
 
 * 修改记录：
-  * 支付宝：新增Client方法：client.UserInfoAuth()，用户登陆授权。（方法未测试通过，待有测试条件的同学测试一下吧）
-  * 支付宝：新增公共方法：alipay.MonitorHeartbeatSyn()，验签接口。（方法未测试通过，待有测试条件的同学测试一下吧）
+    * 支付宝：新增Client方法：client.UserInfoAuth()，用户登陆授权。（方法未测试通过，待有测试条件的同学测试一下吧）
+    * 支付宝：新增公共方法：alipay.MonitorHeartbeatSyn()，验签接口。（方法未测试通过，待有测试条件的同学测试一下吧）
 
 ## 版本号：Release 1.5.3
 
 发布时间：2020/02/19 11:32
 
 * 修改记录：
-  * 支付宝：修改公共方法：SystemOauthToken()，添加参数 signType
+    * 支付宝：修改公共方法：SystemOauthToken()，添加参数 signType
 
 ## 版本号：Release 1.5.2
 
 发布时间：2020/02/14 13:32
 
 * 修改记录：
-  * 支付宝：官方单笔转账接口更新，新增Client方法：client.FundTransUniTransfer()，单笔转账接口
-  * 支付宝：新增Client方法：client.FundTransCommonQuery()，转账业务单据查询接口
-  * 支付宝：新增Client放大：client.FundAccountQuery()，支付宝资金账户资产查询接口
-  * 支付宝：Client的方法，必选参数校验
+    * 支付宝：官方单笔转账接口更新，新增Client方法：client.FundTransUniTransfer()，单笔转账接口
+    * 支付宝：新增Client方法：client.FundTransCommonQuery()，转账业务单据查询接口
+    * 支付宝：新增Client放大：client.FundAccountQuery()，支付宝资金账户资产查询接口
+    * 支付宝：Client的方法，必选参数校验
 
 ## 版本号：Release 1.5.1
 
 发布时间：2020/01/03 17:32
 
 * 修改记录：
-  * 由于下载包需要 /v2 的问题，替换版本号到 1.x，代码不变，只改变版本号记录
+    * 由于下载包需要 /v2 的问题，替换版本号到 1.x，代码不变，只改变版本号记录
 
 ## 版本号：Release 2.0.5
 
 发布时间：2020/01/01 22:55
 
 * 修改记录：
-  * 添加一些函数参数判空操作，避免Panic
-  * 去掉不用的结构体 ReturnMessage
-  * 去掉 go mod v1.4.8版本的依赖
+    * 添加一些函数参数判空操作，避免Panic
+    * 去掉不用的结构体 ReturnMessage
+    * 去掉 go mod v1.4.8版本的依赖
 
 ## 版本号：Release 2.0.4
 
 发布时间：2019/12/24 14:29
 
 * 修改记录：
-  * 支付宝：新增支付宝公钥文件验证签方法（公钥证书模式）：client.VerifySignWithCert()
+    * 支付宝：新增支付宝公钥文件验证签方法（公钥证书模式）：client.VerifySignWithCert()
 
 ## 版本号：Release 2.0.3
 
 发布时间：2019/12/18 19:25
 
 * 修改记录：
-  * 微信：新增Client方法：client.AuthCodeToOpenId()，授权码查询OpenId（正式）
-  * 微信：新增Client方法：client.Report()，交易保障
-  * 微信：新增Client方法：client.EntrustPublic()，公众号纯签约（正式）
-  * 微信：新增Client方法：client.EntrustAppPre()，APP纯签约-预签约接口-获取预签约ID（正式）
-  * 微信：新增Client方法：client.EntrustH5()，H5纯签约（正式）
-  * 微信：新增Client方法：client.EntrustPaying()，支付中签约（正式）
+    * 微信：新增Client方法：client.AuthCodeToOpenId()，授权码查询OpenId（正式）
+    * 微信：新增Client方法：client.Report()，交易保障
+    * 微信：新增Client方法：client.EntrustPublic()，公众号纯签约（正式）
+    * 微信：新增Client方法：client.EntrustAppPre()，APP纯签约-预签约接口-获取预签约ID（正式）
+    * 微信：新增Client方法：client.EntrustH5()，H5纯签约（正式）
+    * 微信：新增Client方法：client.EntrustPaying()，支付中签约（正式）
 
 ## 版本号：Release 2.0.2
 
 发布时间：2019/12/13 23:25
 
 * 修改记录：
-  * 微信：删除Client方法：client.AddCertFileByte()
-  * 版本限制 golang 1.13，fmt.Errorf() 使用 %w 格式化 error，1.13新特性
+    * 微信：删除Client方法：client.AddCertFileByte()
+    * 版本限制 golang 1.13，fmt.Errorf() 使用 %w 格式化 error，1.13新特性
 
 ## 版本号：Release 2.0.1
 
 发布时间：2019/12/13 17:20
 
 * 修改记录：
-  * 处理 go mod 包，go get github.com/iGoogle-ink/gopay/v2
+    * 处理 go mod 包，go get github.com/iGoogle-ink/gopay/v2
 
 ## 版本号：Release 2.0.0
 
 发布时间：2019/12/12 18:22
 
 * 修改记录：
-  * 按支付渠道模块分包大调整
-  * 一大推细小改动，不一一描述了
-  * 支付宝：修改公共API方法：alipay.GetCertSN()，不再支持支付宝根证书的SN获取
-  * 支付宝：新增公共API方法：alipay.GetRootCertSN()，获取root证书序列号SN
-  * 支付宝：新增Client方法：alipay.SetLocation()，设置时区，不设置或出错均为默认服务器时间
+    * 按支付渠道模块分包大调整
+    * 一大推细小改动，不一一描述了
+    * 支付宝：修改公共API方法：alipay.GetCertSN()，不再支持支付宝根证书的SN获取
+    * 支付宝：新增公共API方法：alipay.GetRootCertSN()，获取root证书序列号SN
+    * 支付宝：新增Client方法：alipay.SetLocation()，设置时区，不设置或出错均为默认服务器时间
 
 ## 版本号：Release 1.4.8
 
 发布时间：2019/12/11 16:40
 
 * 修改记录：
-  * 1.几 最后一个版本
-  * 修复一些问题
-  * 支付宝：修改公共API方法：gopay.GetCertSN()，不再支持支付宝根证书的SN获取
-  * 支付宝：新增公共API方法：gopay.GetRootCertSN()，获取root证书序列号SN
-  * 微信：修改公共API方法：gopay.GetWeChatSanBoxParamSign()，修复 沙箱验签出错问题
+    * 1.几 最后一个版本
+    * 修复一些问题
+    * 支付宝：修改公共API方法：gopay.GetCertSN()，不再支持支付宝根证书的SN获取
+    * 支付宝：新增公共API方法：gopay.GetRootCertSN()，获取root证书序列号SN
+    * 微信：修改公共API方法：gopay.GetWeChatSanBoxParamSign()，修复 沙箱验签出错问题
 
 ## 版本号：Release 1.4.6
 
 发布时间：2019/12/09 18:37
 
 * 修改记录：
-  * 移除第三方http请求库，自己封装了一个请求库使用，解决不会设置 goproxy 无法下载包的问题
-  * 使用中如有问题，请微信联系作者处理 或 提issue
+    * 移除第三方http请求库，自己封装了一个请求库使用，解决不会设置 goproxy 无法下载包的问题
+    * 使用中如有问题，请微信联系作者处理 或 提issue
 
 ## 版本号：Release 1.4.5
 
 发布时间：2019/12/07 21:56
 
 * 修改记录：
-  * 支付宝：修复 公钥证书模式 下，同步返回参数接收问题，返回接收结构体增加参数 alipay_cert_sn，同步返回证书模式验签，暂时未解决
-  * 支付宝：修改公共API方法：gopay.VerifyAliPaySign()，不再支持同步验签，只做异步通知验签
-  * 支付宝：新增公共API方法：gopay.VerifyAliPaySyncSign()，支付宝同步返回验签
-  * 支付宝：新增Client方法：client.SetAliPayPublicCertSN()，设置 支付宝公钥证书SN，通过 gopay.GetCertSN() 获取
-    alipay_cert_sn
-  * 支付宝：新增Client方法：client.SetAppCertSnByPath()，设置 app_cert_sn 通过应用公钥证书路径
-  * 支付宝：新增Client方法：client.SetAliPayPublicCertSnByPath()，设置 alipay_cert_sn 通过 支付宝公钥证书文件路径
-  * 支付宝：新增Client方法：client.SetAliPayRootCertSnByPath()，设置 alipay_root_cert_sn 通过支付宝CA根证书文件路径
+    * 支付宝：修复 公钥证书模式 下，同步返回参数接收问题，返回接收结构体增加参数 alipay_cert_sn，同步返回证书模式验签，暂时未解决
+    * 支付宝：修改公共API方法：gopay.VerifyAliPaySign()，不再支持同步验签，只做异步通知验签
+    * 支付宝：新增公共API方法：gopay.VerifyAliPaySyncSign()，支付宝同步返回验签
+    * 支付宝：新增Client方法：client.SetAliPayPublicCertSN()，设置 支付宝公钥证书SN，通过 gopay.GetCertSN() 获取
+      alipay_cert_sn
+    * 支付宝：新增Client方法：client.SetAppCertSnByPath()，设置 app_cert_sn 通过应用公钥证书路径
+    * 支付宝：新增Client方法：client.SetAliPayPublicCertSnByPath()，设置 alipay_cert_sn 通过 支付宝公钥证书文件路径
+    * 支付宝：新增Client方法：client.SetAliPayRootCertSnByPath()，设置 alipay_root_cert_sn 通过支付宝CA根证书文件路径
 
 ## 版本号：Release 1.4.4
 
 发布时间：2019/11/16 15:56
 
 * 修改记录：
-  * 支付宝：新增公共API方法：gopay.ParseAliPayNotifyResultToBodyMap()，解析支付宝支付异步通知的参数到BodyMap
-  * 支付宝：修改公共API方法：gopay.VerifyAliPaySign()，支付宝异步验签支持传入 BodyMap
-  * 微信：新增Client方法：client.AddCertFileByte()，添加微信证书 Byte 数组
-  * 微信：新增Client方法：client.AddCertFilePath()，添加微信证书 Path 路径
-  * 微信：微信Client需要证书的方法，如已使用client.AddCertFilePath()或client.AddCertFileByte()
-    添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传空字符串 ""，否则，3证书Path均不可空
-  * BodyMap 的Set方法去掉switch判断，直接赋值
-  * WeChatClient、AliPayClient 加锁
-  * 修改部分小问题和部分样式
+    * 支付宝：新增公共API方法：gopay.ParseAliPayNotifyResultToBodyMap()，解析支付宝支付异步通知的参数到BodyMap
+    * 支付宝：修改公共API方法：gopay.VerifyAliPaySign()，支付宝异步验签支持传入 BodyMap
+    * 微信：新增Client方法：client.AddCertFileByte()，添加微信证书 Byte 数组
+    * 微信：新增Client方法：client.AddCertFilePath()，添加微信证书 Path 路径
+    * 微信：微信Client需要证书的方法，如已使用client.AddCertFilePath()或client.AddCertFileByte()
+      添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传空字符串 ""，否则，3证书Path均不可空
+    * BodyMap 的Set方法去掉switch判断，直接赋值
+    * WeChatClient、AliPayClient 加锁
+    * 修改部分小问题和部分样式
 
 ## 版本号：Release 1.4.3
 
 发布时间：2019/11/12 01:15
 
 * 修改记录：
-  * 微信：新增公共API方法：gopay.ParseWeChatRefundNotifyResult()，解析微信退款异步通知的请求参数
-  * 微信：新增公共API方法：gopay.DecryptRefundNotifyReqInfo()，解密微信退款异步通知的加密数据
-  * 支付宝：修改Client方法：client.AliPayUserCertifyOpenCertify()，身份认证开始认证（获取认证链接）
-  * 修改部分小问题
+    * 微信：新增公共API方法：gopay.ParseWeChatRefundNotifyResult()，解析微信退款异步通知的请求参数
+    * 微信：新增公共API方法：gopay.DecryptRefundNotifyReqInfo()，解密微信退款异步通知的加密数据
+    * 支付宝：修改Client方法：client.AliPayUserCertifyOpenCertify()，身份认证开始认证（获取认证链接）
+    * 修改部分小问题
 
 ## 版本号：Release 1.4.2
 
 发布时间：2019/11/11 16:43
 
 * 修改记录：
-  * 支付宝：新增Client方法：client.AliPayUserCertifyOpenInit()，身份认证初始化服务
-  * 支付宝：新增Client方法：client.AliPayUserCertifyOpenCertify()，身份认证开始认证
-  * 支付宝：新增Client方法：client.AliPayUserCertifyOpenQuery()，身份认证记录查询
-  * 支付宝：所有方法的返回结构体下的 XxxResponse 字段，统一修改为 Response，如：
-    type AliPayTradeCreateResponse struct {
-    Response createResponse `json:"alipay_trade_create_response,omitempty"`
-    SignData string         `json:"-"`
-    Sign string         `json:"sign"`
-    }
-  * 支付宝：修改一些代码格式问题
-  * 支付宝：client.AlipayOpenAuthTokenApp() 修改为 client.AliPayOpenAuthTokenApp()
+    * 支付宝：新增Client方法：client.AliPayUserCertifyOpenInit()，身份认证初始化服务
+    * 支付宝：新增Client方法：client.AliPayUserCertifyOpenCertify()，身份认证开始认证
+    * 支付宝：新增Client方法：client.AliPayUserCertifyOpenQuery()，身份认证记录查询
+    * 支付宝：所有方法的返回结构体下的 XxxResponse 字段，统一修改为 Response，如：
+      type AliPayTradeCreateResponse struct {
+      Response createResponse `json:"alipay_trade_create_response,omitempty"`
+      SignData string         `json:"-"`
+      Sign string         `json:"sign"`
+      }
+    * 支付宝：修改一些代码格式问题
+    * 支付宝：client.AlipayOpenAuthTokenApp() 修改为 client.AliPayOpenAuthTokenApp()
 
 ## 版本号：Release 1.4.1
 
 发布时间：2019/11/04 14:28
 
 * 修改记录：
-  * 支付宝：修改公共API方法：GetCertSN()，修复获取支付宝根证书获取 sn 的问题（wziww）
-  * 支付宝：新增Client方法：client.SetAppCertSN()，可自行获取公钥 sn 并赋值
-  * 支付宝：新增Client方法：client.SetAliPayRootCertSN()，可自行获取根证书 sn 并赋值
+    * 支付宝：修改公共API方法：GetCertSN()，修复获取支付宝根证书获取 sn 的问题（wziww）
+    * 支付宝：新增Client方法：client.SetAppCertSN()，可自行获取公钥 sn 并赋值
+    * 支付宝：新增Client方法：client.SetAliPayRootCertSN()，可自行获取根证书 sn 并赋值
 
 ## 版本号：Release 1.4.0
 
 发布时间：2019/10/10 13:51
 
 * 修改记录：
-  * AliPayNotifyRequest 结构体，新增加两个字段：method、timestamp，修复电脑网站支付，配置 return_url 支付成功后，支付宝请求该
-    return_url 返回参数验签失败的问题
-  * 去除支付宝老验签方法 VerifyAliPayResultSign()
-  * 去除微信老验签方法 VerifyWeChatResultSign()
+    * AliPayNotifyRequest 结构体，新增加两个字段：method、timestamp，修复电脑网站支付，配置 return_url 支付成功后，支付宝请求该
+      return_url 返回参数验签失败的问题
+    * 去除支付宝老验签方法 VerifyAliPayResultSign()
+    * 去除微信老验签方法 VerifyWeChatResultSign()
 
 ## 版本号：Release 1.3.9
 
 发布时间：2019/09/30 00:01
 
 * 修改记录：
-  * 修复支付宝支付验签出错的问题！
+    * 修复支付宝支付验签出错的问题！
 
 ## 版本号：Release 1.3.8
 
 发布时间：2019/09/24 17:51
 
 * 修改记录：
-  * 代码风格修改更新
+    * 代码风格修改更新
 
 ## 版本号：Release 1.3.7
 
 发布时间：2019/09/22 11:41
 
 * 修改记录：
-  * README 增加 go mod 安装gopay的方法指导
+    * README 增加 go mod 安装gopay的方法指导
 
 ## 版本号：Release 1.3.6
 
 发布时间：2019/09/09 23:51
 
 * 修改记录：
-  * 新增支付宝Client方法：client.AlipayUserInfoShare() => 支付宝会员授权信息查询接口（App支付宝登录）
+    * 新增支付宝Client方法：client.AlipayUserInfoShare() => 支付宝会员授权信息查询接口（App支付宝登录）
 
 ## 版本号：Release 1.3.6
 
 发布时间：2019/09/05 02:55
 
 * 修改记录：
-  * 更改微信公共API方法名称：gopay.GetAccessToken() to gopay.GetWeChatAppletAccessToken() => 获取微信小程序全局唯一后台接口调用凭据
-  * 更改微信公共API方法名称：gopay.GetPaidUnionId() to gopay.GetWeChatAppletPaidUnionId() => 微信小程序用户支付完成后，获取该用户的
-    UnionId，无需用户授权
-  * 新增微信公共API方法：gopay.GetAppWeChatLoginAccessToken() => App应用微信第三方登录，code换取access_token
-  * 新增微信公共API方法：gopay.RefreshAppWeChatLoginAccessToken() => 刷新App应用微信第三方登录后，获取的 access_token
+    * 更改微信公共API方法名称：gopay.GetAccessToken() to gopay.GetWeChatAppletAccessToken() => 获取微信小程序全局唯一后台接口调用凭据
+    * 更改微信公共API方法名称：gopay.GetPaidUnionId() to gopay.GetWeChatAppletPaidUnionId() => 微信小程序用户支付完成后，获取该用户的
+      UnionId，无需用户授权
+    * 新增微信公共API方法：gopay.GetAppWeChatLoginAccessToken() => App应用微信第三方登录，code换取access_token
+    * 新增微信公共API方法：gopay.RefreshAppWeChatLoginAccessToken() => 刷新App应用微信第三方登录后，获取的 access_token
 
 ## 版本号：Release 1.3.5
 
 发布时间：2019/09/05 02:10
 
 * 修改记录：
-  * 支付宝、微信Client 由私有改为公有
+    * 支付宝、微信Client 由私有改为公有
 
 ## 版本号：Release 1.3.4
 
 发布时间：2019/09/03 19:26
 
 * 修改记录：
-  * 新增支付宝公共API方法：gopay.GetCertSN() => 获取证书SN号（app_cert_sn、alipay_root_cert_sn、alipay_cert_sn）
-  * 新增支付宝Client方法：client.SetAliPayRootCertSN() => 设置支付宝根证书SN，通过 gopay.GetCertSN() 获取
-  * 新增支付宝Client方法：client.SetAppCertSN() => 设置应用公钥证书SN，通过 gopay.GetCertSN() 获取
+    * 新增支付宝公共API方法：gopay.GetCertSN() => 获取证书SN号（app_cert_sn、alipay_root_cert_sn、alipay_cert_sn）
+    * 新增支付宝Client方法：client.SetAliPayRootCertSN() => 设置支付宝根证书SN，通过 gopay.GetCertSN() 获取
+    * 新增支付宝Client方法：client.SetAppCertSN() => 设置应用公钥证书SN，通过 gopay.GetCertSN() 获取

--- a/release_note.md
+++ b/release_note.md
@@ -1,8 +1,8 @@
 ## 版本号：v1.5.120
 
 * 修改记录：
-    * 微信v3：新增接口。
-        * 直连商户签约（4 个 channel 各自独立函数）：
+    * 微信v3：新增 扣费服务（预约扣费）相关接口。
+        * 预签约（4 个渠道各自独立函数）：
             * `client.V3ScheduledDeductPreSignMiniProgram()`，小程序预签约。
             * `client.V3ScheduledDeductPreSignApp()`，APP 预签约。
             * `client.V3ScheduledDeductPreSignH5()`，H5 预签约。
@@ -16,13 +16,47 @@
             * `client.V3ScheduledDeductApply()`，受理扣款。
         * 回调通知载荷模型：`PapayScheduledSignNotifyResource`（签解约结果）、`PapayScheduledPayNotifyResource`
           （支付结果）；回调验签 / 解密复用现有 `wechat.V3DecryptNotifyCipherTextToStruct` 等公共方法。
-        * 其他
-            * `client.V3TransferPreTransferWithAuth()`，发起转账并完成免确认收款授权
-            * `client.V3TransferUserConfirmAuth()`，发起免确认收款授权
-            * `client.V3TransferUserConfirmAuthQuery()`，商户单号查询授权结果
-            * `client.V3TransferUserConfirmAuthClose()`，解除免确认收款授权
-            * `client.V3TransferElecsignDownload()`，下载电子回单
-            * `client.V3ComplaintResponseImmediateService()`，回复需要即时服务的投诉单
+    * 微信v3：新增 商家转账（免确认收款授权）相关接口。
+        * `client.V3TransferPreTransferWithAuth()`，发起转账并完成免确认收款授权（一步式，POST）。
+        * `client.V3TransferUserConfirmAuth()`，发起免确认收款授权（仅授权，POST）。
+        * `client.V3TransferUserConfirmAuthQuery()`，商户单号查询授权结果（GET）。
+        * `client.V3TransferUserConfirmAuthClose()`，解除免确认收款授权（POST）。
+    * 微信v3：商家转账（新版）补充。
+        * `client.V3TransferElecsignDownload()`，下载电子回单（GET `/v3/transferdownload/signfile`，传 `TransferElecsignQuery.DownloadURL` 返回 PDF 字节）。
+    * 微信v3：消费者投诉 2.0 补充。
+        * `client.V3ComplaintResponseImmediateService()`，回复需要即时服务的投诉单（POST，2024-09 上线）。
+    * PayPal：新增接口。
+        * `client.FindEligiblePaymentMethods()`，可用支付方式查询（POST `/v2/payments/find-eligible-methods`，返回 paypal/venmo/paylater/card 等多种支付源）。
+        * `client.UpdateTracker()`，更新或取消订单物流信息（PATCH `/v2/checkout/orders/{order_id}/trackers/{tracker_id}`，仅支持 op=replace/add，status 仅可改 CANCELLED）。
+        * `client.InvoiceTemplateDetail()`，发票模板详情查询（GET `/v2/invoicing/templates/{template_id}`）。
+    * PayPal：BREAKING CHANGE。
+        * `client.InvoiceNumberGenerate(ctx, invoiceNumber string)` → `client.InvoiceNumberGenerate(ctx, fetchId bool)`。按 spec 重写：`fetch_id=true` 返回 `invoice_id`，否则返回 `invoice_number`。配套 `InvoiceNumber` 结构新增 `InvoiceId` 字段。
+        * `QRCodeBase64` 拆分为 `Image []byte`（PNG 原始字节）+ `Base64 string`（base64 字符串）。修复 `InvoiceGenerateQRCode` 对 multipart/form-data 响应的解析（此前 `Base64Image` 直接装载整个 multipart 信封，无法直接使用）。
+        * `PartialPayment.MinimumAmount` (`*Amount`) → `MinimumAmountDue` (`*Money`)。原字段名与 spec 不一致，反序列化永远失败。
+        * Invoice 子模块金额字段 `*Amount` → `*Money`（`InvoicePayments.PaidAmount`、`PaymentDetail.Amount`、`InvoiceRefunds.RefundAmount`、`RefundDetail.Amount`）。`Money` 只含 `currency_code/value`，不含 `breakdown`。
+        * `ShipItem.Quantity` 类型 `int` → `string`（spec pattern `^[1-9][0-9]{0,9}$`）。
+        * `PayoutBatchDetail.TotalPage` → `TotalPages`（修正 JSON tag 拼写，原字段反序列化失败）。
+        * `Amount.PurchaseUnitBreakdown` 由值类型改为 `*PurchaseUnitBreakdown`，加 `omitempty`，避免空 breakdown 反序列化报错。
+        * `PaymentSetupTokenDetail.Ordinal` 字段移除（spec 中不存在）。
+    * PayPal：v1.5.119 内联订阅计划字段补充使用说明。
+        * `Item.BillingPlan`（`*OrderBillingPlan`）：Orders v2 API 创建订单时支持内联订阅计划（循环扣款 / 保存支付方式 / 分期），配合 `OrderBillingPlan` / `OrderBillingCycle` 类型使用。
+    * PayPal：参数校验补充（按 spec required）。
+        * `OrderConfirm`：必填 `payment_source`；接受 204 No Content。
+        * `CreateBillingPlan`：必填补 `name`、`payment_preferences`。
+        * `SubscriptionActivate`：移除 `reason` 必填（spec 中为可选）。
+        * `SubscriptionTransactionList`：必填 `start_time`、`end_time`。
+        * `ListAllPaymentTokens`：必填 query `customer_id`。
+    * PayPal：行为修复。
+        * 多个 GET 接口在 BodyMap 为空时不再拼接多余的 `?`：`OrderDetail`、`ShowPayoutBatchDetails`、`ProductList`、`ProductDetails`、`PlanList`、`SubscriptionDetails`。
+        * `InvoiceSearch` URI 重复拼接 bug 修复。
+        * `PaymentReauthorize` / `PaymentAuthorizeCapture` / `PaymentCaptureRefund` / `AddTrackingNumber` 兼容返回 200 与 201；`PaymentAuthorizeVoid` 兼容 200 与 204。
+        * `Patch.Value` 加 `omitempty`，支持 op=remove 无 value 场景。
+    * PayPal：新增模型 / 字段。
+        * 新增类型：`Money`、`InvoiceTemplateDetailRsp`、`SupplementaryData`、`RelatedIds`、`UniversalCode`、`FindEligibleMethodsRsp` / `FindEligibleMethodsResponse`。
+        * `PaymentAuthorizeDetail`、`PaymentAuthorizeCapture` 新增 `Payee` 字段；`PaymentAuthorizeCapture` 新增 `SupplementaryData`（含 `related_ids.order_id` / `authorization_id`）。
+        * `BatchHeader` 新增 `TimeClosed`、`Displayable` 字段。
+        * `PricingScheme` 新增 `Status`、`Version`、`CreateTime`、`UpdateTime` 字段。
+        * `ShipItem` 新增 `Upc` 字段（UPC 商品条码）。
 
 ## 版本号：v1.5.119
 

--- a/release_note.md
+++ b/release_note.md
@@ -1,6 +1,7 @@
 ## 版本号：v1.5.120
 
 * 修改记录：
+    * gopay：golang.org/x/crypto 版本升级到 v0.53.0，module 版本 go 1.25.0。
     * 微信v3：新增 扣费服务（预约扣费）相关接口。
         * 预签约（4 个渠道各自独立函数）：
             * `client.V3ScheduledDeductPreSignMiniProgram()`，小程序预签约。
@@ -16,47 +17,22 @@
             * `client.V3ScheduledDeductApply()`，受理扣款。
         * 回调通知载荷模型：`PapayScheduledSignNotifyResource`（签解约结果）、`PapayScheduledPayNotifyResource`
           （支付结果）；回调验签 / 解密复用现有 `wechat.V3DecryptNotifyCipherTextToStruct` 等公共方法。
-    * 微信v3：新增 商家转账（免确认收款授权）相关接口。
-        * `client.V3TransferPreTransferWithAuth()`，发起转账并完成免确认收款授权（一步式，POST）。
-        * `client.V3TransferUserConfirmAuth()`，发起免确认收款授权（仅授权，POST）。
-        * `client.V3TransferUserConfirmAuthQuery()`，商户单号查询授权结果（GET）。
-        * `client.V3TransferUserConfirmAuthClose()`，解除免确认收款授权（POST）。
-    * 微信v3：商家转账（新版）补充。
-        * `client.V3TransferElecsignDownload()`，下载电子回单（GET `/v3/transferdownload/signfile`，传 `TransferElecsignQuery.DownloadURL` 返回 PDF 字节）。
-    * 微信v3：消费者投诉 2.0 补充。
-        * `client.V3ComplaintResponseImmediateService()`，回复需要即时服务的投诉单（POST，2024-09 上线）。
-    * PayPal：新增接口。
-        * `client.FindEligiblePaymentMethods()`，可用支付方式查询（POST `/v2/payments/find-eligible-methods`，返回 paypal/venmo/paylater/card 等多种支付源）。
-        * `client.UpdateTracker()`，更新或取消订单物流信息（PATCH `/v2/checkout/orders/{order_id}/trackers/{tracker_id}`，仅支持 op=replace/add，status 仅可改 CANCELLED）。
-        * `client.InvoiceTemplateDetail()`，发票模板详情查询（GET `/v2/invoicing/templates/{template_id}`）。
-    * PayPal：BREAKING CHANGE。
-        * `client.InvoiceNumberGenerate(ctx, invoiceNumber string)` → `client.InvoiceNumberGenerate(ctx, fetchId bool)`。按 spec 重写：`fetch_id=true` 返回 `invoice_id`，否则返回 `invoice_number`。配套 `InvoiceNumber` 结构新增 `InvoiceId` 字段。
-        * `QRCodeBase64` 拆分为 `Image []byte`（PNG 原始字节）+ `Base64 string`（base64 字符串）。修复 `InvoiceGenerateQRCode` 对 multipart/form-data 响应的解析（此前 `Base64Image` 直接装载整个 multipart 信封，无法直接使用）。
-        * `PartialPayment.MinimumAmount` (`*Amount`) → `MinimumAmountDue` (`*Money`)。原字段名与 spec 不一致，反序列化永远失败。
-        * Invoice 子模块金额字段 `*Amount` → `*Money`（`InvoicePayments.PaidAmount`、`PaymentDetail.Amount`、`InvoiceRefunds.RefundAmount`、`RefundDetail.Amount`）。`Money` 只含 `currency_code/value`，不含 `breakdown`。
-        * `ShipItem.Quantity` 类型 `int` → `string`（spec pattern `^[1-9][0-9]{0,9}$`）。
-        * `PayoutBatchDetail.TotalPage` → `TotalPages`（修正 JSON tag 拼写，原字段反序列化失败）。
-        * `Amount.PurchaseUnitBreakdown` 由值类型改为 `*PurchaseUnitBreakdown`，加 `omitempty`，避免空 breakdown 反序列化报错。
-        * `PaymentSetupTokenDetail.Ordinal` 字段移除（spec 中不存在）。
-    * PayPal：v1.5.119 内联订阅计划字段补充使用说明。
-        * `Item.BillingPlan`（`*OrderBillingPlan`）：Orders v2 API 创建订单时支持内联订阅计划（循环扣款 / 保存支付方式 / 分期），配合 `OrderBillingPlan` / `OrderBillingCycle` 类型使用。
-    * PayPal：参数校验补充（按 spec required）。
-        * `OrderConfirm`：必填 `payment_source`；接受 204 No Content。
-        * `CreateBillingPlan`：必填补 `name`、`payment_preferences`。
-        * `SubscriptionActivate`：移除 `reason` 必填（spec 中为可选）。
-        * `SubscriptionTransactionList`：必填 `start_time`、`end_time`。
-        * `ListAllPaymentTokens`：必填 query `customer_id`。
-    * PayPal：行为修复。
-        * 多个 GET 接口在 BodyMap 为空时不再拼接多余的 `?`：`OrderDetail`、`ShowPayoutBatchDetails`、`ProductList`、`ProductDetails`、`PlanList`、`SubscriptionDetails`。
-        * `InvoiceSearch` URI 重复拼接 bug 修复。
-        * `PaymentReauthorize` / `PaymentAuthorizeCapture` / `PaymentCaptureRefund` / `AddTrackingNumber` 兼容返回 200 与 201；`PaymentAuthorizeVoid` 兼容 200 与 204。
-        * `Patch.Value` 加 `omitempty`，支持 op=remove 无 value 场景。
-    * PayPal：新增模型 / 字段。
-        * 新增类型：`Money`、`InvoiceTemplateDetailRsp`、`SupplementaryData`、`RelatedIds`、`UniversalCode`、`FindEligibleMethodsRsp` / `FindEligibleMethodsResponse`。
-        * `PaymentAuthorizeDetail`、`PaymentAuthorizeCapture` 新增 `Payee` 字段；`PaymentAuthorizeCapture` 新增 `SupplementaryData`（含 `related_ids.order_id` / `authorization_id`）。
-        * `BatchHeader` 新增 `TimeClosed`、`Displayable` 字段。
-        * `PricingScheme` 新增 `Status`、`Version`、`CreateTime`、`UpdateTime` 字段。
-        * `ShipItem` 新增 `Upc` 字段（UPC 商品条码）。
+        * 新增 商家转账（免确认收款授权）相关接口。
+            * `client.V3TransferPreTransferWithAuth()`，发起转账并完成免确认收款授权（一步式，POST）。
+            * `client.V3TransferUserConfirmAuth()`，发起免确认收款授权（仅授权，POST）。
+            * `client.V3TransferUserConfirmAuthQuery()`，商户单号查询授权结果（GET）。
+            * `client.V3TransferUserConfirmAuthClose()`，解除免确认收款授权（POST）。
+        * 商家转账（新版）补充。
+            * `client.V3TransferElecsignDownload()`，下载电子回单
+        * 消费者投诉 2.0 补充。
+            * `client.V3ComplaintResponseImmediateService()`，回复需要即时服务的投诉单（POST，2024-09 上线）。
+    * PayPal：
+        * 新增接口。
+            * `client.FindEligiblePaymentMethods()`，可用支付方式查询
+            * `client.UpdateTracker()`，更新或取消订单物流信息
+            * `client.InvoiceTemplateDetail()`，发票模板详情查询
+        * 其他
+            * 参数校验补充，model模型完善，部分已知问题修复。
 
 ## 版本号：v1.5.119
 

--- a/wechat/v3/complaint.go
+++ b/wechat/v3/complaint.go
@@ -297,6 +297,35 @@ func (c *ClientV3) V3ComplaintComplete(ctx context.Context, complaintId string, 
 	return wxRsp, c.verifySyncSign(si)
 }
 
+// 回复需要即时服务的投诉单（即时响应消息）
+// 文档：https://pay.weixin.qq.com/doc/v3/merchant/4017151596.md
+// 2024-09 上线，配合 ComplaintListItem.NeedImmediateService=true 使用。
+// 请求体走 message.blocks 协议（TEXT/IMAGE/LINK/FAQ_LIST/BUTTON 等多种 block），结构复杂，
+// 调用方通过 BodyMap 自行构造，顶层 4 个字段：complainted_mchid / message / message_sender_identity / idempotent_id。
+// 响应：200 OK 返回 log_id（与协商历史 log_id 对应）。
+func (c *ClientV3) V3ComplaintResponseImmediateService(ctx context.Context, complaintId string, bm gopay.BodyMap) (*ComplaintResponseImmediateServiceRsp, error) {
+	url := fmt.Sprintf(v3ComplaintResponseImmediateService, complaintId)
+	authorization, err := c.authorization(MethodPost, url, bm)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdPost(ctx, bm, url, authorization)
+	if err != nil {
+		return nil, err
+	}
+	wxRsp := &ComplaintResponseImmediateServiceRsp{Code: Success, SignInfo: si, Response: &ComplaintResponseImmediateService{}}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		_ = js.UnmarshalBytes(bs, &wxRsp.ErrResponse)
+		return wxRsp, nil
+	}
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	return wxRsp, c.verifySyncSign(si)
+}
+
 // 更新退款审批结果
 // Code = 0 is success
 func (c *ClientV3) V3ComplaintUpdateRefundProgress(ctx context.Context, complaintId string, bm gopay.BodyMap) (wxRsp *EmptyRsp, err error) {

--- a/wechat/v3/constant.go
+++ b/wechat/v3/constant.go
@@ -202,18 +202,19 @@ const (
 	v3GoldPlanCloseAdShow  = "/v3/goldplan/merchants/close-advertising-show"          // 关闭广告展示 POST
 
 	// 消费者投诉2.0
-	v3ComplaintList                 = "/v3/merchant-service/complaints-v2"                           // 查询投诉单列表 GET
-	v3ComplaintDetail               = "/v3/merchant-service/complaints-v2/%s"                        // complaint_id 查询投诉单详情 GET
-	v3ComplaintNegotiationHistory   = "/v3/merchant-service/complaints-v2/%s/negotiation-historys"   // complaint_id 查询投诉协商历史 GET
-	v3ComplaintNotifyUrlCreate      = "/v3/merchant-service/complaint-notifications"                 // 创建投诉通知回调地址 POST
-	v3ComplaintNotifyUrlQuery       = "/v3/merchant-service/complaint-notifications"                 // 查询投诉通知回调地址 GET
-	v3ComplaintNotifyUrlUpdate      = "/v3/merchant-service/complaint-notifications"                 // 查询投诉通知回调地址 PUT
-	v3ComplaintNotifyUrlDelete      = "/v3/merchant-service/complaint-notifications"                 // 删除投诉通知回调地址 DELETE
-	v3ComplaintResponse             = "/v3/merchant-service/complaints-v2/%s/response"               // complaint_id 回复用户 POST
-	v3ComplaintComplete             = "/v3/merchant-service/complaints-v2/%s/complete"               // complaint_id 反馈处理完成 POST
-	v3ComplaintUpdateRefundProgress = "/v3/merchant-service/complaints-v2/%s/update-refund-progress" // complaint_id 更新退款审批结果 POST
-	v3ComplaintUploadImage          = "/v3/merchant-service/images/upload"                           // 商户上传反馈图片 POST
-	v3ComplaintImage                = "/v3/merchant-service/images/%s"                               // media_id 图片请求接口 GET
+	v3ComplaintList                     = "/v3/merchant-service/complaints-v2"                               // 查询投诉单列表 GET
+	v3ComplaintDetail                   = "/v3/merchant-service/complaints-v2/%s"                            // complaint_id 查询投诉单详情 GET
+	v3ComplaintNegotiationHistory       = "/v3/merchant-service/complaints-v2/%s/negotiation-historys"       // complaint_id 查询投诉协商历史 GET
+	v3ComplaintNotifyUrlCreate          = "/v3/merchant-service/complaint-notifications"                     // 创建投诉通知回调地址 POST
+	v3ComplaintNotifyUrlQuery           = "/v3/merchant-service/complaint-notifications"                     // 查询投诉通知回调地址 GET
+	v3ComplaintNotifyUrlUpdate          = "/v3/merchant-service/complaint-notifications"                     // 查询投诉通知回调地址 PUT
+	v3ComplaintNotifyUrlDelete          = "/v3/merchant-service/complaint-notifications"                     // 删除投诉通知回调地址 DELETE
+	v3ComplaintResponse                 = "/v3/merchant-service/complaints-v2/%s/response"                   // complaint_id 回复用户 POST
+	v3ComplaintComplete                 = "/v3/merchant-service/complaints-v2/%s/complete"                   // complaint_id 反馈处理完成 POST
+	v3ComplaintUpdateRefundProgress     = "/v3/merchant-service/complaints-v2/%s/update-refund-progress"     // complaint_id 更新退款审批结果 POST
+	v3ComplaintResponseImmediateService = "/v3/merchant-service/complaints-v2/%s/response-immediate-service" // complaint_id 回复需要即时服务的投诉单 POST（2024-09 上线）
+	v3ComplaintUploadImage              = "/v3/merchant-service/images/upload"                               // 商户上传反馈图片 POST
+	v3ComplaintImage                    = "/v3/merchant-service/images/%s"                                   // media_id 图片请求接口 GET
 
 	// 商户平台处置通知
 	v3ViolationNotifyUrlCreate = "/v3/merchant-risk-manage/violation-notifications" // 创建商户违规通知回调地址 POST
@@ -267,6 +268,13 @@ const (
 	V3TransferElecsignMerchantQuery = "/v3/fund-app/mch-transfer/elecsign/out-bill-no/%s"              // 商户单号查询电子回单 GET
 	V3TransferElecsign              = "/v3/fund-app/mch-transfer/elecsign/transfer-bill-no"            // 微信单号申请电子回单 POST
 	V3TransferElecsignQuery         = "/v3/fund-app/mch-transfer/elecsign/transfer-bill-no/%s"         // 微信单号查询电子回单 GET
+	V3TransferElecsignDownload      = "/v3/transferdownload/signfile"                                  // 下载电子回单 GET（query: token）
+
+	// 用户授权免确认收款（商家转账 2025-05 新增）
+	V3TransferPreTransferWithAuth  = "/v3/fund-app/mch-transfer/transfer-bills/pre-transfer-with-authorization"           // 发起转账并完成免确认收款授权 POST
+	V3TransferUserConfirmAuth      = "/v3/fund-app/mch-transfer/user-confirm-authorization"                               // 发起免确认收款授权 POST
+	V3TransferUserConfirmAuthQry   = "/v3/fund-app/mch-transfer/user-confirm-authorization/out-authorization-no/%s"       // out_authorization_no 商户单号查询授权结果 GET
+	V3TransferUserConfirmAuthClose = "/v3/fund-app/mch-transfer/user-confirm-authorization/out-authorization-no/%s/close" // out_authorization_no 解除免确认收款授权 POST
 
 	// 平台收付通（余额查询）
 	v3MerchantBalance     = "/v3/merchant/fund/balance/%s"        // account_type 查询账户实时余额 GET

--- a/wechat/v3/constant.go
+++ b/wechat/v3/constant.go
@@ -324,6 +324,21 @@ const (
 	// 扣款服务-直连模式（其他相关接口在v2接口中）
 	v3EntrustPayNotify = "/v3/papay/contracts/%s/notify" // contract_id 预扣费通知 POST
 
+	// 扣费服务（预约扣费）—— 签约
+	v3ScheduledDeductPreSignMiniProgram = "/v3/papay/scheduled-deduct-sign/contracts/pre-entrust-sign/mini-program" // 小程序预签约 POST
+	v3ScheduledDeductPreSignApp         = "/v3/papay/scheduled-deduct-sign/contracts/pre-entrust-sign/app"          // APP 预签约 POST
+	v3ScheduledDeductPreSignH5          = "/v3/papay/scheduled-deduct-sign/contracts/pre-entrust-sign/h5"           // H5 预签约 POST
+	v3ScheduledDeductPreSignJsapi       = "/v3/papay/scheduled-deduct-sign/contracts/pre-entrust-sign/jsapi"        // JSAPI 预签约 POST
+
+	// 扣费服务（预约扣费）—— 协议管理
+	v3ScheduledDeductContractQuery     = "/v3/papay/sign/contracts/plan-id/%s/out-contract-code/%s"           // plan_id, out_contract_code 通过商户协议号查询签约 GET
+	v3ScheduledDeductContractTerminate = "/v3/papay/sign/contracts/plan-id/%s/out-contract-code/%s/terminate" // plan_id, out_contract_code 通过商户协议号解约 POST
+
+	// 扣费服务（预约扣费）—— 扣款
+	v3ScheduledDeductSchedule      = "/v3/papay/pay/schedules/contract-id/%s/schedule" // contract_id 创建预约扣费 POST
+	v3ScheduledDeductScheduleQuery = "/v3/papay/pay/schedules/contract-id/%s"          // contract_id 查询预约扣费结果 GET
+	v3ScheduledDeductApply         = "/v3/papay/pay/transactions/apply"                // 受理扣款 POST
+
 	// 刷掌支付
 	v3PalmServicePreAuthorize = "/v3/palmservice/authorization/preauthorize" // 用户自主录掌&预授权 POST
 	v3PalmServiceOpenidQuery  = "/v3/palmservice/authorization/openid/%s"    // organization_id 预授权状态查询 GET

--- a/wechat/v3/model_complaint.go
+++ b/wechat/v3/model_complaint.go
@@ -36,6 +36,20 @@ type ComplaintNotifyUrlRsp struct {
 	Error       string              `json:"-"`
 }
 
+// 回复需要即时服务的投诉单 Rsp
+type ComplaintResponseImmediateServiceRsp struct {
+	Code        int                                `json:"-"`
+	SignInfo    *SignInfo                          `json:"-"`
+	Response    *ComplaintResponseImmediateService `json:"response,omitempty"`
+	ErrResponse ErrResponse                        `json:"err_response,omitempty"`
+	Error       string                             `json:"-"`
+}
+
+// 回复需要即时服务的投诉单响应。
+type ComplaintResponseImmediateService struct {
+	LogId string `json:"log_id"` // 操作流水号，与协商历史接口 log_id 对应
+}
+
 // =========================================================分割=========================================================
 
 type ComplaintList struct {
@@ -62,6 +76,8 @@ type ComplaintListItem struct {
 	ApplyRefundAmount     int                   `json:"apply_refund_amount"`
 	UserTagList           []string              `json:"user_tag_list"`
 	AdditionalInfo        *AdditionalInfo       `json:"additional_info"`
+	InPlatformService     bool                  `json:"in_platform_service,omitempty"`    // 投诉单是否正处在平台协助流程中（2024-09 新增）
+	NeedImmediateService  bool                  `json:"need_immediate_service,omitempty"` // 是否需要商户更即时地响应（2024-09 新增）
 }
 
 type ComplaintOrderInfo struct {
@@ -82,12 +98,18 @@ type ComplaintMediaList struct {
 }
 
 type AdditionalInfo struct {
-	Type           string          `json:"type"`
-	SharePowerInfo *SharePowerInfo `json:"share_power_info"`
+	Type           string          `json:"type"`             // 补充信息类型，枚举值：SHARE_POWER_TYPE（充电宝投诉相关行业）
+	SharePowerInfo *SharePowerInfo `json:"share_power_info"` // 当 type=SHARE_POWER_TYPE 时返回
 }
 
 type SharePowerInfo struct {
-	ReturnTime string `json:"return_time"`
+	ReturnTime        string             `json:"return_time"`                   // 归还充电宝的时间
+	ReturnAddressInfo *ReturnAddressInfo `json:"return_address_info,omitempty"` // 归还地址信息（2024-09 新增）
+}
+
+// 充电宝归还地址信息。
+type ReturnAddressInfo struct {
+	IsReturnedToSameMachine bool `json:"is_returned_to_same_machine,omitempty"` // 用户声明是否将充电宝归还至与借取时同一柜机
 }
 
 type ComplaintDetail struct {
@@ -109,6 +131,8 @@ type ComplaintDetail struct {
 	ApplyRefundAmount     int                   `json:"apply_refund_amount"`
 	UserTagList           []string              `json:"user_tag_list"`
 	AdditionalInfo        *AdditionalInfo       `json:"additional_info"`
+	InPlatformService     bool                  `json:"in_platform_service,omitempty"`    // 投诉单是否正处在平台协助流程中（2024-09 新增）
+	NeedImmediateService  bool                  `json:"need_immediate_service,omitempty"` // 是否需要商户更即时地响应（2024-09 新增）
 }
 
 type ComplaintNegotiationHistory struct {

--- a/wechat/v3/model_favor.go
+++ b/wechat/v3/model_favor.go
@@ -1,5 +1,20 @@
 package wechat
 
+// 代金券状态枚举。
+// 文档：https://pay.weixin.qq.com/doc/v3/merchant/4012486942.md
+const (
+	FavorCouponStatusSended  = "SENDED"  // 可用
+	FavorCouponStatusUsed    = "USED"    // 已实扣
+	FavorCouponStatusExpired = "EXPIRED" // 已过期
+	FavorCouponStatusRecover = "RECOVER" // 已回收（2025-05 新增）
+	FavorCouponStatusRevoked = "REVOKED" // 已撤回
+)
+
+// 代金券细分业务类型。
+const (
+	FavorBusinessTypeMultiuse = "MULTIUSE" // 消费金类型（2024-08 新增）
+)
+
 // 创建代金券批次 Rsp
 type FavorBatchCreateRsp struct {
 	Code        int               `json:"-"`
@@ -303,22 +318,34 @@ type FavorBatchList struct {
 }
 
 type FavorBatch struct {
-	StockId            string        `json:"stock_id"`             // 微信为每个代金券批次分配的唯一Id
-	StockCreatorMchid  string        `json:"stock_creator_mchid"`  // 创建批次的商户号
-	StockName          string        `json:"stock_name"`           // 批次名称
-	Status             string        `json:"status"`               // 批次状态
-	CreateTime         string        `json:"create_time"`          // 创建时间，遵循rfc3339标准格式
-	Description        string        `json:"description"`          // 使用说明
-	StockUseRule       *StockUseRule `json:"stock_use_rule"`       // 普通发券批次特定信息
-	AvailableBeginTime string        `json:"available_begin_time"` // 可用开始时间，遵循rfc3339标准格式
-	AvailableEndTime   string        `json:"available_end_time"`   // 可用结束时间，遵循rfc3339标准格式
-	DistributedCoupons int           `json:"distributed_coupons"`  // 已发券数量
-	NoCash             bool          `json:"no_cash"`              // 是否无资金流
-	StartTime          string        `json:"start_time"`           // 激活批次的时间
-	StopTime           string        `json:"stop_time"`            // 终止批次的时间
-	CutToMessage       *CutToMessage `json:"cut_to_message"`       // 单品优惠特定信息
-	Singleitem         bool          `json:"singleitem"`           // 是否单品优惠
-	StockType          string        `json:"stock_type"`           // 批次类型
+	StockId               string             `json:"stock_id"`                          // 微信为每个代金券批次分配的唯一Id
+	StockCreatorMchid     string             `json:"stock_creator_mchid"`               // 创建批次的商户号
+	StockName             string             `json:"stock_name"`                        // 批次名称
+	Status                string             `json:"status"`                            // 批次状态
+	CreateTime            string             `json:"create_time"`                       // 创建时间，遵循rfc3339标准格式
+	Description           string             `json:"description"`                       // 使用说明
+	StockUseRule          *StockUseRule      `json:"stock_use_rule"`                    // 普通发券批次特定信息
+	AvailableBeginTime    string             `json:"available_begin_time"`              // 可用开始时间，遵循rfc3339标准格式
+	AvailableEndTime      string             `json:"available_end_time"`                // 可用结束时间，遵循rfc3339标准格式
+	DistributedCoupons    int                `json:"distributed_coupons"`               // 已发券数量
+	NoCash                bool               `json:"no_cash"`                           // 是否无资金流
+	StartTime             string             `json:"start_time"`                        // 激活批次的时间
+	StopTime              string             `json:"stop_time"`                         // 终止批次的时间
+	CutToMessage          *CutToMessage      `json:"cut_to_message"`                    // 单品优惠特定信息
+	Singleitem            bool               `json:"singleitem"`                        // 是否单品优惠
+	StockType             string             `json:"stock_type"`                        // 批次类型
+	BusinessType          string             `json:"business_type,omitempty"`           // 细分业务类型，仅 MULTIUSE 时返回（2024-08 新增）
+	AvailableRegionList   []*AvailableRegion `json:"available_region_list,omitempty"`   // 消费金可用地域列表，仅 business_type=MULTIUSE 时返回
+	AvailableIndustryList []string           `json:"available_industry_list,omitempty"` // 消费金可用行业列表，仅 business_type=MULTIUSE 时返回
+}
+
+// 消费金可用地域。
+type AvailableRegion struct {
+	Type     string `json:"type,omitempty"`     // 地域精度：PROVINCE/CITY/DISTRICT/COUNTRY
+	Province string `json:"province,omitempty"` // 省
+	City     string `json:"city,omitempty"`     // 市
+	District string `json:"district,omitempty"` // 区
+	Country  string `json:"country,omitempty"`  // 国家
 }
 
 type StockUseRule struct {
@@ -344,20 +371,22 @@ type CutToMessage struct {
 }
 
 type FavorDetail struct {
-	StockId                 string                   `json:"stock_id"`                  // 微信为每个代金券批次分配的唯一Id
-	StockCreatorMchid       string                   `json:"stock_creator_mchid"`       // 创建批次的商户号
-	CouponId                string                   `json:"coupon_id"`                 // 微信为代金券唯一分配的id
-	CutToMessage            *CutToMessage            `json:"cut_to_message"`            // 单品优惠特定信息
-	CouponName              string                   `json:"coupon_name"`               // 代金券名称
-	Status                  string                   `json:"status"`                    // 代金券状态
-	Description             string                   `json:"description"`               // 使用说明
-	CreateTime              string                   `json:"create_time"`               // 领券时间，遵循rfc3339标准格式
-	CouponType              string                   `json:"coupon_type"`               // 券类型
-	NoCash                  bool                     `json:"no_cash"`                   // 是否无资金流
-	AvailableBeginTime      string                   `json:"available_begin_time"`      // 可用开始时间，遵循rfc3339标准格式
-	AvailableEndTime        string                   `json:"available_end_time"`        // 可用结束时间，遵循rfc3339标准格式
-	Singleitem              bool                     `json:"singleitem"`                // 是否单品优惠
-	NormalCouponInformation *NormalCouponInformation `json:"normal_coupon_information"` // 普通满减券面额、门槛信息
+	StockId                 string                   `json:"stock_id"`                    // 微信为每个代金券批次分配的唯一Id
+	StockCreatorMchid       string                   `json:"stock_creator_mchid"`         // 创建批次的商户号
+	CouponId                string                   `json:"coupon_id"`                   // 微信为代金券唯一分配的id
+	CutToMessage            *CutToMessage            `json:"cut_to_message"`              // 单品优惠特定信息
+	CouponName              string                   `json:"coupon_name"`                 // 代金券名称
+	Status                  string                   `json:"status"`                      // 代金券状态：SENDED/USED/EXPIRED/RECOVER/REVOKED，见 FavorCouponStatus* 常量
+	Description             string                   `json:"description"`                 // 使用说明
+	CreateTime              string                   `json:"create_time"`                 // 领券时间，遵循rfc3339标准格式
+	CouponType              string                   `json:"coupon_type"`                 // 券类型
+	NoCash                  bool                     `json:"no_cash"`                     // 是否无资金流
+	AvailableBeginTime      string                   `json:"available_begin_time"`        // 可用开始时间，遵循rfc3339标准格式
+	AvailableEndTime        string                   `json:"available_end_time"`          // 可用结束时间，遵循rfc3339标准格式
+	Singleitem              bool                     `json:"singleitem"`                  // 是否单品优惠
+	NormalCouponInformation *NormalCouponInformation `json:"normal_coupon_information"`   // 普通满减券面额、门槛信息
+	AvailableBalance        int                      `json:"available_balance,omitempty"` // 剩余金额（分），仅 business_type=MULTIUSE 时返回（2024-08 新增）
+	BusinessType            string                   `json:"business_type,omitempty"`     // 细分业务类型：MULTIUSE，见 FavorBusinessType* 常量
 }
 
 type NormalCouponInformation struct {
@@ -394,16 +423,18 @@ type UserCoupon struct {
 	CouponId                string                   `json:"coupon_id"`
 	CouponName              string                   `json:"coupon_name"`
 	CouponType              string                   `json:"coupon_type"`
-	CutToMessage            *CutToMessage            `json:"cut_to_message"`            // 单品优惠特定信息
-	Status                  string                   `json:"status"`                    // 代金券状态
-	Description             string                   `json:"description"`               // 使用说明
-	CreateTime              string                   `json:"create_time"`               // 领券时间，遵循rfc3339标准格式
-	NoCash                  bool                     `json:"no_cash"`                   // 是否无资金流
-	AvailableBeginTime      string                   `json:"available_begin_time"`      // 可用开始时间，遵循rfc3339标准格式
-	AvailableEndTime        string                   `json:"available_end_time"`        // 可用结束时间，遵循rfc3339标准格式
-	Singleitem              bool                     `json:"singleitem"`                // 是否单品优惠
-	NormalCouponInformation *NormalCouponInformation `json:"normal_coupon_information"` // 普通满减券面额、门槛信息
-	ConsumeInformation      *ConsumeInformation      `json:"consume_information"`       // 已实扣代金券信息
+	CutToMessage            *CutToMessage            `json:"cut_to_message"`              // 单品优惠特定信息
+	Status                  string                   `json:"status"`                      // 代金券状态：SENDED/USED/EXPIRED/RECOVER/REVOKED，见 FavorCouponStatus* 常量
+	Description             string                   `json:"description"`                 // 使用说明
+	CreateTime              string                   `json:"create_time"`                 // 领券时间，遵循rfc3339标准格式
+	NoCash                  bool                     `json:"no_cash"`                     // 是否无资金流
+	AvailableBeginTime      string                   `json:"available_begin_time"`        // 可用开始时间，遵循rfc3339标准格式
+	AvailableEndTime        string                   `json:"available_end_time"`          // 可用结束时间，遵循rfc3339标准格式
+	Singleitem              bool                     `json:"singleitem"`                  // 是否单品优惠
+	NormalCouponInformation *NormalCouponInformation `json:"normal_coupon_information"`   // 普通满减券面额、门槛信息
+	ConsumeInformation      *ConsumeInformation      `json:"consume_information"`         // 已实扣代金券信息
+	AvailableBalance        int                      `json:"available_balance,omitempty"` // 剩余金额（分），仅 business_type=MULTIUSE 时返回（2024-08 新增）
+	BusinessType            string                   `json:"business_type,omitempty"`     // 细分业务类型：MULTIUSE，见 FavorBusinessType* 常量
 }
 
 type ConsumeInformation struct {

--- a/wechat/v3/model_papay.go
+++ b/wechat/v3/model_papay.go
@@ -1,0 +1,270 @@
+package wechat
+
+// ===================== 扣费服务（预约扣费） · 状态枚举 =====================
+
+// 委托代扣协议状态。
+// 文档：https://pay.weixin.qq.com/doc/v3/merchant/4012489245
+const (
+	PapayContractStateSigned      = "SIGNED"        // 签约生效中
+	PapayContractStateTerminated  = "TERMINATED"    // 已解约
+	PapayContractStateSignFailed  = "SIGN_FAILED"   // 用户同意签约但因业务规则限制导致签约失败
+	PapayContractStateToBeRenewed = "TO_BE_RENEWED" // 可续期的计划，等待商户传入续期计划
+)
+
+// 协议解约方式。
+const (
+	PapayTerminationModeUser            = "USER_TERMINATE"             // 用户发起的解约
+	PapayTerminationModeMchAPI          = "MCH_API_TERMINATE"          // 商户通过 API 发起的解约
+	PapayTerminationModeWepayWeb        = "WEPAY_WEB_TERMINATE"        // 商户在商户平台发起的解约
+	PapayTerminationModeCustomerService = "CUSTOMER_SERVICE_TERMINATE" // 用户联系微信支付客服发起的解约
+	PapayTerminationModeSystem          = "SYSTEM_TERMINATE"           // 微信支付系统主动发起的解约
+)
+
+// 扣费预约状态。
+const (
+	PapayScheduleStateNoScheduled = "NO_SCHEDULED" // 未进行预约
+	PapayScheduleStateScheduled   = "SCHEDULED"    // 已预约成功，未发起扣费或已发起扣费但扣费失败
+	PapayScheduleStatePaid        = "PAID"         // 已发起扣费且扣费成功
+	PapayScheduleStateExpired     = "EXPIRED"      // 超过预计扣费时间且没有扣费成功
+)
+
+// ===================== Rsp 包装 =====================
+
+// 小程序预签约 Rsp
+type PapayScheduledPreSignMiniProgramRsp struct {
+	Code        int                               `json:"-"`
+	SignInfo    *SignInfo                         `json:"-"`
+	Response    *PapayScheduledPreSignMiniProgram `json:"response,omitempty"`
+	ErrResponse ErrResponse                       `json:"err_response,omitempty"`
+	Error       string                            `json:"-"`
+}
+
+// APP 预签约 Rsp
+type PapayScheduledPreSignAppRsp struct {
+	Code        int                       `json:"-"`
+	SignInfo    *SignInfo                 `json:"-"`
+	Response    *PapayScheduledPreSignApp `json:"response,omitempty"`
+	ErrResponse ErrResponse               `json:"err_response,omitempty"`
+	Error       string                    `json:"-"`
+}
+
+// H5 预签约 Rsp
+type PapayScheduledPreSignH5Rsp struct {
+	Code        int                      `json:"-"`
+	SignInfo    *SignInfo                `json:"-"`
+	Response    *PapayScheduledPreSignH5 `json:"response,omitempty"`
+	ErrResponse ErrResponse              `json:"err_response,omitempty"`
+	Error       string                   `json:"-"`
+}
+
+// JSAPI 预签约 Rsp
+type PapayScheduledPreSignJsapiRsp struct {
+	Code        int                         `json:"-"`
+	SignInfo    *SignInfo                   `json:"-"`
+	Response    *PapayScheduledPreSignJsapi `json:"response,omitempty"`
+	ErrResponse ErrResponse                 `json:"err_response,omitempty"`
+	Error       string                      `json:"-"`
+}
+
+// 协议查询 / 协议解约 Rsp（响应结构一致，复用同一 wrapper）
+type PapayScheduledContractRsp struct {
+	Code        int                     `json:"-"`
+	SignInfo    *SignInfo               `json:"-"`
+	Response    *PapayScheduledContract `json:"response,omitempty"`
+	ErrResponse ErrResponse             `json:"err_response,omitempty"`
+	Error       string                  `json:"-"`
+}
+
+// 创建预约扣费 / 查询预约扣费 Rsp（响应结构一致）
+type PapayScheduledScheduleRsp struct {
+	Code        int                     `json:"-"`
+	SignInfo    *SignInfo               `json:"-"`
+	Response    *PapayScheduledSchedule `json:"response,omitempty"`
+	ErrResponse ErrResponse             `json:"err_response,omitempty"`
+	Error       string                  `json:"-"`
+}
+
+// 受理扣款 Rsp
+type PapayScheduledApplyRsp struct {
+	Code        int                  `json:"-"`
+	SignInfo    *SignInfo            `json:"-"`
+	Response    *PapayScheduledApply `json:"response,omitempty"`
+	ErrResponse ErrResponse          `json:"err_response,omitempty"`
+	Error       string               `json:"-"`
+}
+
+// ===================== 公共子类型 =====================
+
+// 金额信息。文档统一使用 total。
+// 部分回调文档表格里写作 "amount"，但 JSON 实例仍是 "total"，按 JSON 实例为准。
+type PapayScheduledAmount struct {
+	Total    int    `json:"total"`              // 总金额，单位：分
+	Currency string `json:"currency,omitempty"` // 币种，默认 CNY
+}
+
+// 协议解约信息。仅在 contract_state=TERMINATED 时返回。
+type PapayScheduledContractTerminateInfo struct {
+	ContractTerminationMode   string `json:"contract_termination_mode"`             // 协议解约方式，见 PapayTerminationMode* 常量
+	ContractTerminatedTime    string `json:"contract_terminated_time"`              // 协议解约时间，rfc3339
+	ContractTerminationRemark string `json:"contract_termination_remark,omitempty"` // 解约备注
+}
+
+// 预约扣费场景的预约信息。仅在预约扣费类型的协议中返回。
+type PapayScheduledDeductScheduleDetail struct {
+	EstimatedDeductDate   string                `json:"estimated_deduct_date,omitempty"`   // 预计扣费日期，yyyy-MM-DD
+	EstimatedDeductAmount *PapayScheduledAmount `json:"estimated_deduct_amount,omitempty"` // 预计扣费金额
+	ScheduleState         string                `json:"schedule_state,omitempty"`          // 扣费预约状态，见 PapayScheduleState* 常量
+	ScheduledAmount       *PapayScheduledAmount `json:"scheduled_amount,omitempty"`        // 已预约的扣费金额，状态为已预约/已扣费时返回
+	DeductAmount          *PapayScheduledAmount `json:"deduct_amount,omitempty"`           // 实际扣费金额，状态为已扣费时返回
+	DeductDate            string                `json:"deduct_date,omitempty"`             // 实际扣费日期，状态为已扣费时返回，yyyy-MM-DD
+}
+
+// ===================== 预签约响应 =====================
+
+// 小程序预签约响应。文档：4012525209
+// 调用方据此向客户端下发用于 navigateToMiniProgram 的参数。
+type PapayScheduledPreSignMiniProgram struct {
+	PreEntrustwebId string `json:"pre_entrustweb_id"` // 预签约 ID，10 分钟内有效
+	RedirectAppid   string `json:"redirect_appid"`    // 跳转签约小程序的 AppID
+	RedirectPath    string `json:"redirect_path"`     // 跳转签约小程序的路径
+}
+
+// APP 预签约响应。文档：4012524934
+// 后两字段仅在满足模板条件时返回，否则只返回 PreEntrustwebId。
+type PapayScheduledPreSignApp struct {
+	PreEntrustwebId     string `json:"pre_entrustweb_id"`              // 预签约 ID，10 分钟内有效
+	MiniprogramUsername string `json:"miniprogram_username,omitempty"` // 跳转签约小程序的 username（仅 2025-09-23 后或申请 WXLaunchMiniProgram 权限的模板返回）
+	MiniprogramPath     string `json:"miniprogram_path,omitempty"`     // 跳转签约小程序的 path（同上）
+}
+
+// H5 预签约响应。文档：4012489208
+type PapayScheduledPreSignH5 struct {
+	RedirectUrl string `json:"redirect_url"` // 拉起微信支付客户端的签约页面 URL
+}
+
+// JSAPI 预签约响应。文档：4012525133
+type PapayScheduledPreSignJsapi struct {
+	RedirectUrl string `json:"redirect_url"` // 跳转签约流程的 URL
+}
+
+// ===================== 协议详情（查询 / 解约 复用） =====================
+
+// 委托代扣协议详情。文档：4012489245（查询）、4012489295（解约）
+// 查询与解约接口返回字段完全一致。
+type PapayScheduledContract struct {
+	Mchid                  string                               `json:"mchid"`
+	ContractId             string                               `json:"contract_id"`
+	Appid                  string                               `json:"appid"`
+	PlanId                 int                                  `json:"plan_id"` // 委托代扣模板 ID，文档定义为 integer
+	OutContractCode        string                               `json:"out_contract_code"`
+	ContractDisplayAccount string                               `json:"contract_display_account"`
+	ContractState          string                               `json:"contract_state"`                  // 见 PapayContractState* 常量
+	ContractSignedTime     string                               `json:"contract_signed_time,omitempty"`  // rfc3339；签约失败时不返回
+	ContractExpiredTime    string                               `json:"contract_expired_time,omitempty"` // rfc3339；签约失败时不返回
+	Openid                 string                               `json:"openid"`
+	ContractTerminateInfo  *PapayScheduledContractTerminateInfo `json:"contract_terminate_info,omitempty"` // 仅 TERMINATED 状态返回
+	OutUserCode            string                               `json:"out_user_code,omitempty"`
+	DeductSchedule         *PapayScheduledDeductScheduleDetail  `json:"deduct_schedule,omitempty"` // 仅预约扣费类型模板返回
+}
+
+// ===================== 预约扣费（创建 / 查询 复用） =====================
+
+// 预约扣费详情。文档：4012467036（创建）、4012466997（查询）
+type PapayScheduledSchedule struct {
+	ScheduleState   string                `json:"schedule_state"`              // 见 PapayScheduleState* 常量
+	DeductStartDate string                `json:"deduct_start_date,omitempty"` // 可扣费开始日期，yyyy-MM-DD
+	DeductEndDate   string                `json:"deduct_end_date,omitempty"`   // 可扣费结束日期，yyyy-MM-DD
+	ScheduledAmount *PapayScheduledAmount `json:"scheduled_amount,omitempty"`  // 已预约的扣费金额
+	DeductAmount    *PapayScheduledAmount `json:"deduct_amount,omitempty"`     // 实际扣费金额，预约状态为已扣费时返回
+	DeductDate      string                `json:"deduct_date,omitempty"`       // 实际扣费日期，预约状态为已扣费时返回
+}
+
+// ===================== 受理扣款 =====================
+
+// 受理扣款响应。文档：4012467087
+type PapayScheduledApply struct {
+	OutTradeNo string                `json:"out_trade_no"`
+	Amount     *PapayScheduledAmount `json:"amount"`
+}
+
+// ===================== 回调通知载荷 =====================
+
+// 代扣签解约结果通知载荷。文档：4012286323
+// 商户用 APIv3 密钥 AES-GCM 解密 resource.ciphertext 后 Unmarshal 至此。
+// 与协议查询响应（PapayScheduledContract）字段一致，但 contract_state 仅返回 SIGNED / TERMINATED。
+type PapayScheduledSignNotifyResource struct {
+	Mchid                  string                               `json:"mchid"`
+	ContractId             string                               `json:"contract_id"`
+	Appid                  string                               `json:"appid"`
+	PlanId                 int                                  `json:"plan_id"`
+	OutContractCode        string                               `json:"out_contract_code"`
+	ContractDisplayAccount string                               `json:"contract_display_account"`
+	ContractState          string                               `json:"contract_state"` // SIGNED / TERMINATED
+	ContractSignedTime     string                               `json:"contract_signed_time,omitempty"`
+	ContractExpiredTime    string                               `json:"contract_expired_time,omitempty"`
+	Openid                 string                               `json:"openid"`
+	ContractTerminateInfo  *PapayScheduledContractTerminateInfo `json:"contract_terminate_info,omitempty"`
+	OutUserCode            string                               `json:"out_user_code,omitempty"`
+	DeductSchedule         *PapayScheduledDeductScheduleDetail  `json:"deduct_schedule,omitempty"`
+}
+
+// 代扣支付者信息
+type PapayPayer struct {
+	Openid string `json:"openid"` // 用户在直连商户 AppID 下的唯一标识
+}
+
+// 代扣订单金额信息（支付通知使用）
+type PapayPayNotifyAmount struct {
+	Total         int    `json:"total"`          // 订单总金额，单位：分
+	PayerTotal    int    `json:"payer_total"`    // 用户支付金额，单位：分
+	Currency      string `json:"currency"`       // CNY
+	PayerCurrency string `json:"payer_currency"` // 用户支付币种
+}
+
+// 支付场景信息
+type PapayPayNotifySceneInfo struct {
+	DeviceId string `json:"device_id,omitempty"`
+}
+
+// 商品列表
+type PapayPayNotifyGoodsDetail struct {
+	GoodsId        string `json:"goods_id"`
+	Quantity       int    `json:"quantity"`
+	UnitPrice      int    `json:"unit_price"`
+	DiscountAmount int    `json:"discount_amount"`
+	GoodsRemark    string `json:"goods_remark,omitempty"`
+}
+
+// 优惠功能
+type PapayPayNotifyPromotionDetail struct {
+	CouponId            string                       `json:"coupon_id"`
+	Name                string                       `json:"name,omitempty"`
+	Scope               string                       `json:"scope,omitempty"` // GLOBAL / SINGLE
+	Type                string                       `json:"type,omitempty"`  // CASH / NOCASH
+	Amount              int                          `json:"amount"`
+	StockId             string                       `json:"stock_id,omitempty"`
+	WechatpayContribute int                          `json:"wechatpay_contribute,omitempty"`
+	MerchantContribute  int                          `json:"merchant_contribute,omitempty"`
+	OtherContribute     int                          `json:"other_contribute,omitempty"`
+	Currency            string                       `json:"currency,omitempty"`
+	GoodsDetail         []*PapayPayNotifyGoodsDetail `json:"goods_detail,omitempty"`
+}
+
+// 代扣支付结果通知载荷。文档：4012286313
+// 商户用 APIv3 密钥 AES-GCM 解密 resource.ciphertext 后 Unmarshal 至此。
+type PapayScheduledPayNotifyResource struct {
+	Appid           string                           `json:"appid,omitempty"`
+	Mchid           string                           `json:"mchid"`
+	OutTradeNo      string                           `json:"out_trade_no"`
+	TransactionId   string                           `json:"transaction_id"`
+	TradeType       string                           `json:"trade_type"`  // PAP: 委托代扣
+	TradeState      string                           `json:"trade_state"` // SUCCESS
+	TradeStateDesc  string                           `json:"trade_state_desc"`
+	BankType        string                           `json:"bank_type,omitempty"`
+	Attach          string                           `json:"attach,omitempty"`
+	SuccessTime     string                           `json:"success_time,omitempty"` // rfc3339
+	Payer           *PapayPayer                      `json:"payer,omitempty"`
+	Amount          *PapayPayNotifyAmount            `json:"amount,omitempty"`
+	SceneInfo       *PapayPayNotifySceneInfo         `json:"scene_info,omitempty"`
+	PromotionDetail []*PapayPayNotifyPromotionDetail `json:"promotion_detail,omitempty"`
+}

--- a/wechat/v3/model_pay.go
+++ b/wechat/v3/model_pay.go
@@ -136,10 +136,11 @@ type SubOrders struct {
 }
 
 type CombineAmount struct {
-	TotalAmount   int    `json:"total_amount,omitempty"`   // 订单总金额，单位为分
-	Currency      string `json:"currency,omitempty"`       // 标价币种：符合ISO 4217标准的三位字母代码，人民币：CNY
-	PayerAmount   int    `json:"payer_amount"`             // 订单现金支付金额
-	PayerCurrency string `json:"payer_currency,omitempty"` // 现金支付币种：符合ISO 4217标准的三位字母代码，默认人民币：CNY
+	TotalAmount    int    `json:"total_amount,omitempty"`    // 订单总金额，单位为分
+	Currency       string `json:"currency,omitempty"`        // 标价币种：符合ISO 4217标准的三位字母代码，人民币：CNY
+	PayerAmount    int    `json:"payer_amount"`              // 订单现金支付金额
+	PayerCurrency  string `json:"payer_currency,omitempty"`  // 现金支付币种：符合ISO 4217标准的三位字母代码，默认人民币：CNY
+	SettlementRate int    `json:"settlement_rate,omitempty"` // 结算汇率，标价币种和商品单商户号的结算币种不一致时才返回（汇率值是汇率乘以10的8次方，如 6.5 → 650000000）
 }
 
 type CombineQueryOrder struct {

--- a/wechat/v3/model_transfer_bills.go
+++ b/wechat/v3/model_transfer_bills.go
@@ -1,5 +1,13 @@
 package wechat
 
+// 商家转账 user_recv_style.type 枚举：用户收款样式（2025-05 新增功能）。
+// 文档：https://pay.weixin.qq.com/doc/v3/merchant/4012716434.md
+// 使用方式：bm.Set("user_recv_style", gopay.BodyMap{"type": TransferUserRecvStyleRedPacket})
+const (
+	TransferUserRecvStyleConfirmPage = "CONFIRM_PAGE" // 收款确认页样式（默认）
+	TransferUserRecvStyleRedPacket   = "RED_PACKET"   // 红包样式（单笔金额 ≤ 200 元）
+)
+
 // 发起转账 Rsp
 type TransferBillsRsp struct {
 	Code        int            `json:"-"`
@@ -148,4 +156,94 @@ type TransferElecsignQuery struct {
 	HashValue   string `json:"hash_value"`
 	DownloadURL string `json:"download_url"`
 	FailReason  string `json:"fail_reason"`
+}
+
+// ===================== 用户授权免确认收款（2025-05 新增） =====================
+
+// 发起转账并完成免确认收款授权 Rsp
+type TransferPreTransferWithAuthRsp struct {
+	Code        int                          `json:"-"`
+	SignInfo    *SignInfo                    `json:"-"`
+	Response    *TransferPreTransferWithAuth `json:"response,omitempty"`
+	ErrResponse ErrResponse                  `json:"err_response,omitempty"`
+	Error       string                       `json:"-"`
+}
+
+type TransferPreTransferWithAuth struct {
+	OutBillNo          string `json:"out_bill_no"`
+	TransferBillNo     string `json:"transfer_bill_no"`
+	CreateTime         string `json:"create_time"`
+	State              string `json:"state"`
+	PackageInfo        string `json:"package_info"` // 调起授权页所需的 package 串
+	UserDisplayName    string `json:"user_display_name"`
+	OutAuthorizationNo string `json:"out_authorization_no"`
+}
+
+// 发起免确认收款授权 Rsp
+type TransferUserConfirmAuthRsp struct {
+	Code        int                      `json:"-"`
+	SignInfo    *SignInfo                `json:"-"`
+	Response    *TransferUserConfirmAuth `json:"response,omitempty"`
+	ErrResponse ErrResponse              `json:"err_response,omitempty"`
+	Error       string                   `json:"-"`
+}
+
+type TransferUserConfirmAuth struct {
+	OutAuthorizationNo string `json:"out_authorization_no"`
+	State              string `json:"state"`
+	CreateTime         string `json:"create_time"`
+	PackageInfo        string `json:"package_info"` // 调起授权页所需的 package 串
+}
+
+// 商户单号查询授权结果 Rsp
+type TransferUserConfirmAuthQryRsp struct {
+	Code        int                         `json:"-"`
+	SignInfo    *SignInfo                   `json:"-"`
+	Response    *TransferUserConfirmAuthQry `json:"response,omitempty"`
+	ErrResponse ErrResponse                 `json:"err_response,omitempty"`
+	Error       string                      `json:"-"`
+}
+
+type TransferUserConfirmAuthQry struct {
+	OutAuthorizationNo string                 `json:"out_authorization_no"`
+	Appid              string                 `json:"appid"`
+	Openid             string                 `json:"openid,omitempty"`
+	UserDisplayName    string                 `json:"user_display_name,omitempty"`
+	AuthorizationId    string                 `json:"authorization_id,omitempty"`
+	State              string                 `json:"state"`
+	AuthorizeTime      string                 `json:"authorize_time,omitempty"`
+	CloseInfo          *TransferAuthCloseInfo `json:"close_info,omitempty"`
+	TransferSceneId    string                 `json:"transfer_scene_id,omitempty"`
+	UserRecvPerception string                 `json:"user_recv_perception,omitempty"`
+	CreateTime         string                 `json:"create_time,omitempty"`
+	PackageInfo        string                 `json:"package_info,omitempty"` // 当 query 参数 is_display_authorization=true 时返回
+}
+
+// 解除免确认收款授权 Rsp
+type TransferUserConfirmAuthCloseRsp struct {
+	Code        int                           `json:"-"`
+	SignInfo    *SignInfo                     `json:"-"`
+	Response    *TransferUserConfirmAuthClose `json:"response,omitempty"`
+	ErrResponse ErrResponse                   `json:"err_response,omitempty"`
+	Error       string                        `json:"-"`
+}
+
+type TransferUserConfirmAuthClose struct {
+	OutAuthorizationNo string                 `json:"out_authorization_no"`
+	Appid              string                 `json:"appid"`
+	Openid             string                 `json:"openid,omitempty"`
+	UserDisplayName    string                 `json:"user_display_name,omitempty"`
+	AuthorizationId    string                 `json:"authorization_id,omitempty"`
+	State              string                 `json:"state"`
+	AuthorizeTime      string                 `json:"authorize_time,omitempty"`
+	CloseInfo          *TransferAuthCloseInfo `json:"close_info,omitempty"`
+	TransferSceneId    string                 `json:"transfer_scene_id,omitempty"`
+	UserRecvPerception string                 `json:"user_recv_perception,omitempty"`
+	CreateTime         string                 `json:"create_time,omitempty"`
+}
+
+// 授权关闭信息。
+type TransferAuthCloseInfo struct {
+	CloseTime   string `json:"close_time,omitempty"`
+	CloseReason string `json:"close_reason,omitempty"`
 }

--- a/wechat/v3/papay_scheduled.go
+++ b/wechat/v3/papay_scheduled.go
@@ -1,0 +1,256 @@
+package wechat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-pay/gopay"
+	"github.com/go-pay/util/js"
+)
+
+// 扣费服务（预约扣费）—— 小程序预签约
+// 微信文档：https://pay.weixin.qq.com/doc/v3/merchant/4012525209
+// 必填字段：appid, openid, plan_id (integer), out_contract_code, contract_display_account, contract_notify_url
+// 选填字段：out_user_code, deduct_schedule{estimated_deduct_date, estimated_deduct_amount{total, currency}, description}
+// Code = 0 is success
+func (c *ClientV3) V3ScheduledDeductPreSignMiniProgram(ctx context.Context, bm gopay.BodyMap) (wxRsp *PapayScheduledPreSignMiniProgramRsp, err error) {
+	authorization, err := c.authorization(MethodPost, v3ScheduledDeductPreSignMiniProgram, bm)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdPost(ctx, bm, v3ScheduledDeductPreSignMiniProgram, authorization)
+	if err != nil {
+		return nil, err
+	}
+	wxRsp = &PapayScheduledPreSignMiniProgramRsp{Code: Success, SignInfo: si, Response: new(PapayScheduledPreSignMiniProgram)}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		_ = js.UnmarshalBytes(bs, &wxRsp.ErrResponse)
+		return wxRsp, nil
+	}
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	return wxRsp, c.verifySyncSign(si)
+}
+
+// 扣费服务（预约扣费）—— APP 预签约
+// 微信文档：https://pay.weixin.qq.com/doc/v3/merchant/4012524934
+// 必填字段：appid, plan_id (integer), out_contract_code, contract_display_account, contract_notify_url
+// 选填字段：out_user_code, deduct_schedule{...}
+// Code = 0 is success
+func (c *ClientV3) V3ScheduledDeductPreSignApp(ctx context.Context, bm gopay.BodyMap) (wxRsp *PapayScheduledPreSignAppRsp, err error) {
+	authorization, err := c.authorization(MethodPost, v3ScheduledDeductPreSignApp, bm)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdPost(ctx, bm, v3ScheduledDeductPreSignApp, authorization)
+	if err != nil {
+		return nil, err
+	}
+	wxRsp = &PapayScheduledPreSignAppRsp{Code: Success, SignInfo: si, Response: new(PapayScheduledPreSignApp)}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		_ = js.UnmarshalBytes(bs, &wxRsp.ErrResponse)
+		return wxRsp, nil
+	}
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	return wxRsp, c.verifySyncSign(si)
+}
+
+// 扣费服务（预约扣费）—— H5 预签约
+// 微信文档：https://pay.weixin.qq.com/doc/v3/merchant/4012489208
+// 必填字段：appid, plan_id (integer), out_contract_code, contract_display_account, contract_notify_url
+// 选填字段：out_user_code, deduct_schedule{...}
+// Code = 0 is success
+func (c *ClientV3) V3ScheduledDeductPreSignH5(ctx context.Context, bm gopay.BodyMap) (wxRsp *PapayScheduledPreSignH5Rsp, err error) {
+	authorization, err := c.authorization(MethodPost, v3ScheduledDeductPreSignH5, bm)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdPost(ctx, bm, v3ScheduledDeductPreSignH5, authorization)
+	if err != nil {
+		return nil, err
+	}
+	wxRsp = &PapayScheduledPreSignH5Rsp{Code: Success, SignInfo: si, Response: new(PapayScheduledPreSignH5)}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		_ = js.UnmarshalBytes(bs, &wxRsp.ErrResponse)
+		return wxRsp, nil
+	}
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	return wxRsp, c.verifySyncSign(si)
+}
+
+// 扣费服务（预约扣费）—— JSAPI 预签约
+// 微信文档：https://pay.weixin.qq.com/doc/v3/merchant/4012525133
+// 必填字段：appid, openid, plan_id (integer), out_contract_code, contract_display_account, contract_notify_url
+// 选填字段：out_user_code, deduct_schedule{...}
+// Code = 0 is success
+func (c *ClientV3) V3ScheduledDeductPreSignJsapi(ctx context.Context, bm gopay.BodyMap) (wxRsp *PapayScheduledPreSignJsapiRsp, err error) {
+	authorization, err := c.authorization(MethodPost, v3ScheduledDeductPreSignJsapi, bm)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdPost(ctx, bm, v3ScheduledDeductPreSignJsapi, authorization)
+	if err != nil {
+		return nil, err
+	}
+	wxRsp = &PapayScheduledPreSignJsapiRsp{Code: Success, SignInfo: si, Response: new(PapayScheduledPreSignJsapi)}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		_ = js.UnmarshalBytes(bs, &wxRsp.ErrResponse)
+		return wxRsp, nil
+	}
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	return wxRsp, c.verifySyncSign(si)
+}
+
+// 扣费服务（预约扣费）—— 通过商户协议号查询签约
+// 微信文档：https://pay.weixin.qq.com/doc/v3/merchant/4012489245
+// 路径参数：plan_id（委托代扣模板 ID）、out_contract_code（商户协议号）
+// Code = 0 is success
+func (c *ClientV3) V3ScheduledDeductContractQuery(ctx context.Context, planId, outContractCode string) (wxRsp *PapayScheduledContractRsp, err error) {
+	uri := fmt.Sprintf(v3ScheduledDeductContractQuery, planId, outContractCode)
+	authorization, err := c.authorization(MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdGet(ctx, uri, authorization)
+	if err != nil {
+		return nil, err
+	}
+	wxRsp = &PapayScheduledContractRsp{Code: Success, SignInfo: si, Response: new(PapayScheduledContract)}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		_ = js.UnmarshalBytes(bs, &wxRsp.ErrResponse)
+		return wxRsp, nil
+	}
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	return wxRsp, c.verifySyncSign(si)
+}
+
+// 扣费服务（预约扣费）—— 通过商户协议号解约
+// 微信文档：https://pay.weixin.qq.com/doc/v3/merchant/4012489295
+// 路径参数：plan_id、out_contract_code
+// 必填字段：contract_termination_remark（解约备注）
+// Code = 0 is success
+func (c *ClientV3) V3ScheduledDeductContractTerminate(ctx context.Context, planId, outContractCode string, bm gopay.BodyMap) (wxRsp *PapayScheduledContractRsp, err error) {
+	uri := fmt.Sprintf(v3ScheduledDeductContractTerminate, planId, outContractCode)
+	authorization, err := c.authorization(MethodPost, uri, bm)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdPost(ctx, bm, uri, authorization)
+	if err != nil {
+		return nil, err
+	}
+	wxRsp = &PapayScheduledContractRsp{Code: Success, SignInfo: si, Response: new(PapayScheduledContract)}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		_ = js.UnmarshalBytes(bs, &wxRsp.ErrResponse)
+		return wxRsp, nil
+	}
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	return wxRsp, c.verifySyncSign(si)
+}
+
+// 扣费服务（预约扣费）—— 创建预约扣费
+// 微信文档：https://pay.weixin.qq.com/doc/v3/merchant/4012467036
+// 路径参数：contract_id（委托代扣协议 ID）
+// 必填字段：appid, schedule_amount{total, currency}
+// Code = 0 is success
+func (c *ClientV3) V3ScheduledDeductSchedule(ctx context.Context, contractId string, bm gopay.BodyMap) (wxRsp *PapayScheduledScheduleRsp, err error) {
+	uri := fmt.Sprintf(v3ScheduledDeductSchedule, contractId)
+	authorization, err := c.authorization(MethodPost, uri, bm)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdPost(ctx, bm, uri, authorization)
+	if err != nil {
+		return nil, err
+	}
+	wxRsp = &PapayScheduledScheduleRsp{Code: Success, SignInfo: si, Response: new(PapayScheduledSchedule)}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		_ = js.UnmarshalBytes(bs, &wxRsp.ErrResponse)
+		return wxRsp, nil
+	}
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	return wxRsp, c.verifySyncSign(si)
+}
+
+// 扣费服务（预约扣费）—— 查询预约扣费结果
+// 微信文档：https://pay.weixin.qq.com/doc/v3/merchant/4012466997
+// 路径参数：contract_id
+// Code = 0 is success
+func (c *ClientV3) V3ScheduledDeductScheduleQuery(ctx context.Context, contractId string) (wxRsp *PapayScheduledScheduleRsp, err error) {
+	uri := fmt.Sprintf(v3ScheduledDeductScheduleQuery, contractId)
+	authorization, err := c.authorization(MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdGet(ctx, uri, authorization)
+	if err != nil {
+		return nil, err
+	}
+	wxRsp = &PapayScheduledScheduleRsp{Code: Success, SignInfo: si, Response: new(PapayScheduledSchedule)}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		_ = js.UnmarshalBytes(bs, &wxRsp.ErrResponse)
+		return wxRsp, nil
+	}
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	return wxRsp, c.verifySyncSign(si)
+}
+
+// 扣费服务（预约扣费）—— 受理扣款
+// 微信文档：https://pay.weixin.qq.com/doc/v3/merchant/4012467087
+// 必填字段：appid, out_trade_no, description, transaction_notify_url, contract_id, amount{total, currency}
+// 选填字段：goods_tag, attach
+// Code = 0 is success
+func (c *ClientV3) V3ScheduledDeductApply(ctx context.Context, bm gopay.BodyMap) (wxRsp *PapayScheduledApplyRsp, err error) {
+	authorization, err := c.authorization(MethodPost, v3ScheduledDeductApply, bm)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdPost(ctx, bm, v3ScheduledDeductApply, authorization)
+	if err != nil {
+		return nil, err
+	}
+	wxRsp = &PapayScheduledApplyRsp{Code: Success, SignInfo: si, Response: new(PapayScheduledApply)}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		_ = js.UnmarshalBytes(bs, &wxRsp.ErrResponse)
+		return wxRsp, nil
+	}
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	return wxRsp, c.verifySyncSign(si)
+}

--- a/wechat/v3/papay_scheduled_test.go
+++ b/wechat/v3/papay_scheduled_test.go
@@ -1,0 +1,243 @@
+package wechat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/go-pay/gopay"
+	"github.com/go-pay/xlog"
+)
+
+func TestV3ScheduledDeductPreSignMiniProgram(t *testing.T) {
+	bm := make(gopay.BodyMap)
+	bm.Set("appid", "wxd678efh567hg6787").
+		Set("openid", "oYobu0MVnQfWpSMOYJz2AHPG_gQw").
+		Set("plan_id", 12535).
+		Set("out_contract_code", "wxwtdk20200910100000").
+		Set("contract_display_account", "微信代扣用户A").
+		Set("contract_notify_url", "https://yourapp.com/notify")
+
+	wxRsp, err := client.V3ScheduledDeductPreSignMiniProgram(ctx, bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if wxRsp.Code == Success {
+		xlog.Debugf("wxRsp: %+v", wxRsp.Response)
+		return
+	}
+	xlog.Errorf("wxRsp:%s", wxRsp.Error)
+}
+
+func TestV3ScheduledDeductPreSignApp(t *testing.T) {
+	bm := make(gopay.BodyMap)
+	bm.Set("appid", "wxd678efh567hg6787").
+		Set("plan_id", 12535).
+		Set("out_contract_code", "wxwtdk20200910100001").
+		Set("contract_display_account", "微信代扣用户A").
+		Set("contract_notify_url", "https://yourapp.com/notify")
+
+	wxRsp, err := client.V3ScheduledDeductPreSignApp(ctx, bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if wxRsp.Code == Success {
+		xlog.Debugf("wxRsp: %+v", wxRsp.Response)
+		return
+	}
+	xlog.Errorf("wxRsp:%s", wxRsp.Error)
+}
+
+func TestV3ScheduledDeductPreSignH5(t *testing.T) {
+	bm := make(gopay.BodyMap)
+	bm.Set("appid", "wxd678efh567hg6787").
+		Set("plan_id", 12535).
+		Set("out_contract_code", "wxwtdk20200910100002").
+		Set("contract_display_account", "微信代扣用户A").
+		Set("contract_notify_url", "https://yourapp.com/notify")
+
+	wxRsp, err := client.V3ScheduledDeductPreSignH5(ctx, bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if wxRsp.Code == Success {
+		xlog.Debugf("wxRsp: %+v", wxRsp.Response)
+		return
+	}
+	xlog.Errorf("wxRsp:%s", wxRsp.Error)
+}
+
+func TestV3ScheduledDeductPreSignJsapi(t *testing.T) {
+	bm := make(gopay.BodyMap)
+	bm.Set("appid", "wxd678efh567hg6787").
+		Set("openid", "oYobu0MVnQfWpSMOYJz2AHPG_gQw").
+		Set("plan_id", 12535).
+		Set("out_contract_code", "wxwtdk20200910100003").
+		Set("contract_display_account", "微信代扣用户A").
+		Set("contract_notify_url", "https://yourapp.com/notify")
+
+	wxRsp, err := client.V3ScheduledDeductPreSignJsapi(ctx, bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if wxRsp.Code == Success {
+		xlog.Debugf("wxRsp: %+v", wxRsp.Response)
+		return
+	}
+	xlog.Errorf("wxRsp:%s", wxRsp.Error)
+}
+
+func TestV3ScheduledDeductContractQuery(t *testing.T) {
+	wxRsp, err := client.V3ScheduledDeductContractQuery(ctx, "12535", "wxwtdk20200910100000")
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if wxRsp.Code == Success {
+		xlog.Debugf("wxRsp: %+v", wxRsp.Response)
+		return
+	}
+	xlog.Errorf("wxRsp:%s", wxRsp.Error)
+}
+
+func TestV3ScheduledDeductContractTerminate(t *testing.T) {
+	bm := make(gopay.BodyMap)
+	bm.Set("contract_termination_remark", "用户主动解约")
+
+	wxRsp, err := client.V3ScheduledDeductContractTerminate(ctx, "12535", "wxwtdk20200910100000", bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if wxRsp.Code == Success {
+		xlog.Debugf("wxRsp: %+v", wxRsp.Response)
+		return
+	}
+	xlog.Errorf("wxRsp:%s", wxRsp.Error)
+}
+
+func TestV3ScheduledDeductSchedule(t *testing.T) {
+	bm := make(gopay.BodyMap)
+	bm.Set("appid", "wxd678efh567hg6787").
+		SetBodyMap("schedule_amount", func(bm gopay.BodyMap) {
+			bm.Set("total", 1).Set("currency", "CNY")
+		})
+
+	wxRsp, err := client.V3ScheduledDeductSchedule(ctx, "123124412412423431", bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if wxRsp.Code == Success {
+		xlog.Debugf("wxRsp: %+v", wxRsp.Response)
+		return
+	}
+	xlog.Errorf("wxRsp:%s", wxRsp.Error)
+}
+
+func TestV3ScheduledDeductScheduleQuery(t *testing.T) {
+	wxRsp, err := client.V3ScheduledDeductScheduleQuery(ctx, "123124412412423431")
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if wxRsp.Code == Success {
+		xlog.Debugf("wxRsp: %+v", wxRsp.Response)
+		return
+	}
+	xlog.Errorf("wxRsp:%s", wxRsp.Error)
+}
+
+func TestV3ScheduledDeductApply(t *testing.T) {
+	bm := make(gopay.BodyMap)
+	bm.Set("appid", "wxd678efh567hg6787").
+		Set("out_trade_no", "1217752501201407033233368018").
+		Set("description", "测试受理扣款").
+		Set("transaction_notify_url", "https://yourapp.com/pay-notify").
+		Set("contract_id", "123124412412423431").
+		SetBodyMap("amount", func(bm gopay.BodyMap) {
+			bm.Set("total", 1).Set("currency", "CNY")
+		})
+
+	wxRsp, err := client.V3ScheduledDeductApply(ctx, bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	if wxRsp.Code == Success {
+		xlog.Debugf("wxRsp: %+v", wxRsp.Response)
+		return
+	}
+	xlog.Errorf("wxRsp:%s", wxRsp.Error)
+}
+
+// 验证回调 resource 解密后的 JSON 能正确反序列化到 model 上。
+// 测试 JSON 来源：
+//   - 签约通知：https://pay.weixin.qq.com/doc/v3/merchant/4012286323
+//   - 支付通知：https://pay.weixin.qq.com/doc/v3/merchant/4012286313
+func TestPapayScheduledNotifyDecode(t *testing.T) {
+	signPlain := []byte(`{
+		"appid": "wxd678efh567hg6787",
+		"contract_display_account": "微信代扣用户A",
+		"contract_expired_time": "2021-09-10T13:29:35+08:00",
+		"contract_id": "123124412412423431",
+		"contract_signed_time": "2020-09-10T13:29:35+08:00",
+		"contract_state": "SIGNED",
+		"deduct_schedule": {
+			"deduct_amount": {"currency":"CNY","total":1},
+			"deduct_date": "2019-11-22",
+			"estimated_deduct_amount": {"currency":"CNY","total":1},
+			"estimated_deduct_date": "2019-11-22",
+			"schedule_state": "PAID",
+			"scheduled_amount": {"currency":"CNY","total":1}
+		},
+		"mchid": "1900000109",
+		"openid": "o-MYE42l80oelYMDE34nYD456Xoy",
+		"out_contract_code": "wxwtdk20200910100000",
+		"out_user_code": "用户A",
+		"plan_id": 12535
+	}`)
+	sign := new(PapayScheduledSignNotifyResource)
+	if err := json.Unmarshal(signPlain, sign); err != nil {
+		t.Fatalf("sign notify unmarshal: %v", err)
+	}
+	if sign.ContractState != PapayContractStateSigned {
+		t.Fatalf("sign notify contract_state mismatch: %q", sign.ContractState)
+	}
+	if sign.PlanId != 12535 || sign.OutContractCode != "wxwtdk20200910100000" {
+		t.Fatalf("sign notify field mismatch: %+v", sign)
+	}
+	if sign.DeductSchedule == nil || sign.DeductSchedule.ScheduleState != PapayScheduleStatePaid {
+		t.Fatalf("sign notify deduct_schedule mismatch: %+v", sign.DeductSchedule)
+	}
+
+	payPlain := []byte(`{
+		"transaction_id":"1217752501201407033233368018",
+		"amount":{"payer_total":100,"total":100,"currency":"CNY","payer_currency":"CNY"},
+		"mchid":"1230000109",
+		"trade_state":"SUCCESS",
+		"trade_state_desc":"支付成功",
+		"trade_type":"PAP",
+		"bank_type":"CMC",
+		"out_trade_no":"1217752501201407033233368018",
+		"success_time":"2020-09-10T13:29:35+08:00",
+		"payer":{"openid":"o-MYE42l80oelYMDE34nYD456Xoy"},
+		"appid":"wxd678efh567hg6787"
+	}`)
+	pay := new(PapayScheduledPayNotifyResource)
+	if err := json.Unmarshal(payPlain, pay); err != nil {
+		t.Fatalf("pay notify unmarshal: %v", err)
+	}
+	if pay.TradeState != "SUCCESS" || pay.TradeType != "PAP" {
+		t.Fatalf("pay notify state mismatch: %+v", pay)
+	}
+	if pay.Amount == nil || pay.Amount.Total != 100 || pay.Amount.PayerTotal != 100 {
+		t.Fatalf("pay notify amount mismatch: %+v", pay.Amount)
+	}
+	if pay.Payer == nil || pay.Payer.Openid == "" {
+		t.Fatalf("pay notify payer mismatch: %+v", pay.Payer)
+	}
+}

--- a/wechat/v3/transfer_authorization.go
+++ b/wechat/v3/transfer_authorization.go
@@ -1,0 +1,118 @@
+package wechat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-pay/gopay"
+	"github.com/go-pay/util/js"
+)
+
+// 发起转账并完成免确认收款授权（一步式）
+// 文档：https://pay.weixin.qq.com/doc/v3/merchant/4014399293.md
+// 2025-05 新增。一次接口同时拉起授权 + 发起转账，返回 package_info 由前端调起授权页。
+func (c *ClientV3) V3TransferPreTransferWithAuth(ctx context.Context, bm gopay.BodyMap) (*TransferPreTransferWithAuthRsp, error) {
+	authorization, err := c.authorization(MethodPost, V3TransferPreTransferWithAuth, bm)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdPost(ctx, bm, V3TransferPreTransferWithAuth, authorization)
+	if err != nil {
+		return nil, err
+	}
+	wxRsp := &TransferPreTransferWithAuthRsp{Code: Success, SignInfo: si, Response: &TransferPreTransferWithAuth{}}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		_ = js.UnmarshalBytes(bs, &wxRsp.ErrResponse)
+		return wxRsp, nil
+	}
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	return wxRsp, c.verifySyncSign(si)
+}
+
+// 发起免确认收款授权（单独申请授权，不发起转账）
+// 文档：https://pay.weixin.qq.com/doc/v3/merchant/4015901167.md
+// 2025-05 新增。返回 package_info 由前端调起授权页让用户确认。
+func (c *ClientV3) V3TransferUserConfirmAuth(ctx context.Context, bm gopay.BodyMap) (*TransferUserConfirmAuthRsp, error) {
+	authorization, err := c.authorization(MethodPost, V3TransferUserConfirmAuth, bm)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdPost(ctx, bm, V3TransferUserConfirmAuth, authorization)
+	if err != nil {
+		return nil, err
+	}
+	wxRsp := &TransferUserConfirmAuthRsp{Code: Success, SignInfo: si, Response: &TransferUserConfirmAuth{}}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		_ = js.UnmarshalBytes(bs, &wxRsp.ErrResponse)
+		return wxRsp, nil
+	}
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	return wxRsp, c.verifySyncSign(si)
+}
+
+// 商户单号查询授权结果
+// 文档：https://pay.weixin.qq.com/doc/v3/merchant/4014399423.md
+// query 可选传 is_display_authorization=true 让响应里返回 package_info（2026-06 新增）。
+func (c *ClientV3) V3TransferUserConfirmAuthQuery(ctx context.Context, outAuthorizationNo string, bm gopay.BodyMap) (*TransferUserConfirmAuthQryRsp, error) {
+	uri := fmt.Sprintf(V3TransferUserConfirmAuthQry, outAuthorizationNo)
+	if bm != nil {
+		if q := bm.EncodeURLParams(); q != "" {
+			uri = uri + "?" + q
+		}
+	}
+	authorization, err := c.authorization(MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdGet(ctx, uri, authorization)
+	if err != nil {
+		return nil, err
+	}
+	wxRsp := &TransferUserConfirmAuthQryRsp{Code: Success, SignInfo: si, Response: &TransferUserConfirmAuthQry{}}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		_ = js.UnmarshalBytes(bs, &wxRsp.ErrResponse)
+		return wxRsp, nil
+	}
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	return wxRsp, c.verifySyncSign(si)
+}
+
+// 解除免确认收款授权
+// 文档：https://pay.weixin.qq.com/doc/v3/merchant/4015653811.md
+// 无请求体。
+func (c *ClientV3) V3TransferUserConfirmAuthClose(ctx context.Context, outAuthorizationNo string) (*TransferUserConfirmAuthCloseRsp, error) {
+	uri := fmt.Sprintf(V3TransferUserConfirmAuthClose, outAuthorizationNo)
+	authorization, err := c.authorization(MethodPost, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+	res, si, bs, err := c.doProdPost(ctx, nil, uri, authorization)
+	if err != nil {
+		return nil, err
+	}
+	wxRsp := &TransferUserConfirmAuthCloseRsp{Code: Success, SignInfo: si, Response: &TransferUserConfirmAuthClose{}}
+	if res.StatusCode != http.StatusOK {
+		wxRsp.Code = res.StatusCode
+		wxRsp.Error = string(bs)
+		_ = js.UnmarshalBytes(bs, &wxRsp.ErrResponse)
+		return wxRsp, nil
+	}
+	if err = json.Unmarshal(bs, wxRsp.Response); err != nil {
+		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
+	}
+	return wxRsp, c.verifySyncSign(si)
+}

--- a/wechat/v3/transfer_bills.go
+++ b/wechat/v3/transfer_bills.go
@@ -3,8 +3,10 @@ package wechat
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/go-pay/gopay"
 	"github.com/go-pay/util/js"
@@ -197,4 +199,30 @@ func (c *ClientV3) V3TransferElecsignMerchantQuery(ctx context.Context, transfer
 		return nil, fmt.Errorf("[%w]: %v, bytes: %s", gopay.UnmarshalErr, err, string(bs))
 	}
 	return wxRsp, c.verifySyncSign(si)
+}
+
+// 下载电子回单
+// 文档：https://pay.weixin.qq.com/doc/v3/merchant/4013866774.md
+// 用法：传入 TransferElecsignQuery.DownloadURL（带 token 的完整 URL，10 分钟内有效），返回 PDF 文件字节。
+// 下载后建议用查询接口返回的 hash_value（SHA1）校验文件完整性。
+func (c *ClientV3) V3TransferElecsignDownload(ctx context.Context, downloadUrl string) (fileBytes []byte, err error) {
+	if downloadUrl == gopay.NULL {
+		return nil, errors.New("invalid download url")
+	}
+	split := strings.Split(downloadUrl, ".com")
+	if len(split) != 2 {
+		return nil, errors.New("invalid download url")
+	}
+	authorization, err := c.authorization(MethodGet, split[1], nil)
+	if err != nil {
+		return nil, err
+	}
+	res, _, bs, err := c.doProdGet(ctx, split[1], authorization)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New(string(bs))
+	}
+	return bs, nil
 }


### PR DESCRIPTION
## 版本号：v1.5.120

* 修改记录：
    * gopay：golang.org/x/crypto 版本升级到 v0.53.0，module 版本 go 1.25.0。
    * 微信v3：新增 扣费服务（预约扣费）相关接口。
        * 预签约（4 个渠道各自独立函数）：
            * `client.V3ScheduledDeductPreSignMiniProgram()`，小程序预签约。
            * `client.V3ScheduledDeductPreSignApp()`，APP 预签约。
            * `client.V3ScheduledDeductPreSignH5()`，H5 预签约。
            * `client.V3ScheduledDeductPreSignJsapi()`，JSAPI 预签约。
        * 协议管理：
            * `client.V3ScheduledDeductContractQuery()`，通过商户协议号查询签约。
            * `client.V3ScheduledDeductContractTerminate()`，通过商户协议号解约。
        * 预约扣款：
            * `client.V3ScheduledDeductSchedule()`，创建预约扣费。
            * `client.V3ScheduledDeductScheduleQuery()`，查询预约扣费结果。
            * `client.V3ScheduledDeductApply()`，受理扣款。
        * 回调通知载荷模型：`PapayScheduledSignNotifyResource`（签解约结果）、`PapayScheduledPayNotifyResource`
          （支付结果）；回调验签 / 解密复用现有 `wechat.V3DecryptNotifyCipherTextToStruct` 等公共方法。
        * 新增 商家转账（免确认收款授权）相关接口。
            * `client.V3TransferPreTransferWithAuth()`，发起转账并完成免确认收款授权（一步式，POST）。
            * `client.V3TransferUserConfirmAuth()`，发起免确认收款授权（仅授权，POST）。
            * `client.V3TransferUserConfirmAuthQuery()`，商户单号查询授权结果（GET）。
            * `client.V3TransferUserConfirmAuthClose()`，解除免确认收款授权（POST）。
        * 商家转账（新版）补充。
            * `client.V3TransferElecsignDownload()`，下载电子回单
        * 消费者投诉 2.0 补充。
            * `client.V3ComplaintResponseImmediateService()`，回复需要即时服务的投诉单（POST，2024-09 上线）。
    * PayPal：
        * 新增接口。
            * `client.FindEligiblePaymentMethods()`，可用支付方式查询
            * `client.UpdateTracker()`，更新或取消订单物流信息
            * `client.InvoiceTemplateDetail()`，发票模板详情查询
        * 其他
            * 参数校验补充，model模型完善，部分已知问题修复。
